### PR TITLE
feat: add per-notebook dependency management

### DIFF
--- a/apps/api/src/kernel/router.ts
+++ b/apps/api/src/kernel/router.ts
@@ -228,6 +228,8 @@ const handleExecuteRequest = async ({
   const result = await runtime.execute({
     cell: runnableCell,
     code: message.code,
+    notebookId: notebook.id,
+    env: notebook.env,
     timeoutMs: message.timeoutMs,
     onStream: (stream) => {
       sendMessage(connection, { ...stream, cellId: cell.id });

--- a/apps/api/src/kernel/runtime.test.ts
+++ b/apps/api/src/kernel/runtime.test.ts
@@ -1,54 +1,184 @@
 import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { createCodeCell } from "@nodebooks/notebook-schema";
 import { NotebookRuntime } from "./runtime.js";
 
+const createEnv = (packages: Record<string, string> = {}) => ({
+  runtime: "node" as const,
+  version: "20.x",
+  packages,
+});
+
+const createTempRoot = async () => {
+  return fs.mkdtemp(join(tmpdir(), "nodebooks-runtime-test-"));
+};
+
+type RuntimeOptions = ConstructorParameters<typeof NotebookRuntime>[0];
+
+const withRuntime = async (
+  options: RuntimeOptions | undefined,
+  run: (runtime: NotebookRuntime, root: string) => Promise<void>
+) => {
+  const root = await createTempRoot();
+  const runtime = new NotebookRuntime({ ...(options ?? {}), workspaceRoot: root });
+  try {
+    await run(runtime, root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+};
+
 describe("NotebookRuntime", () => {
   it("executes JavaScript and captures console output", async () => {
-    const runtime = new NotebookRuntime();
-    const cell = createCodeCell({ id: "cell-js", language: "js" });
-    const streams: string[] = [];
+    await withRuntime(undefined, async (runtime) => {
+      const cell = createCodeCell({ id: "cell-js", language: "js" });
+      const streams: string[] = [];
 
-    const result = await runtime.execute({
-      cell,
-      code: "console.log('hello runtime'); 2 + 3;",
-      onStream: (output) => {
-        streams.push(output.text.trim());
-      },
+      const result = await runtime.execute({
+        cell,
+        code: "console.log('hello runtime'); 2 + 3;",
+        notebookId: "notebook-basic",
+        env: createEnv(),
+        onStream: (output) => {
+          streams.push(output.text.trim());
+        },
+      });
+
+      expect(result.execution.status).toBe("ok");
+      expect(streams.some((line) => line.includes("hello runtime"))).toBe(
+        true
+      );
+      expect(
+        result.outputs.some((output) => output.type === "display_data")
+      ).toBe(true);
     });
-
-    expect(result.execution.status).toBe("ok");
-    expect(streams.some((line) => line.includes("hello runtime"))).toBe(true);
-    expect(
-      result.outputs.some((output) => output.type === "display_data")
-    ).toBe(true);
   });
 
   it("transpiles TypeScript before execution", async () => {
-    const runtime = new NotebookRuntime();
-    const cell = createCodeCell({ id: "cell-ts", language: "ts" });
+    await withRuntime(undefined, async (runtime) => {
+      const cell = createCodeCell({ id: "cell-ts", language: "ts" });
 
-    const result = await runtime.execute({
-      cell,
-      code: "const add = (a: number, b: number): number => a + b; add(1, 2);",
+      const result = await runtime.execute({
+        cell,
+        code: "const add = (a: number, b: number): number => a + b; add(1, 2);",
+        notebookId: "notebook-ts",
+        env: createEnv(),
+      });
+
+      expect(result.execution.status).toBe("ok");
+      expect(
+        result.outputs.some((output) => output.type === "display_data")
+      ).toBe(true);
     });
-
-    expect(result.execution.status).toBe("ok");
-    expect(
-      result.outputs.some((output) => output.type === "display_data")
-    ).toBe(true);
   });
 
   it("reports execution errors", async () => {
-    const runtime = new NotebookRuntime();
-    const cell = createCodeCell({ id: "cell-error", language: "js" });
+    await withRuntime(undefined, async (runtime) => {
+      const cell = createCodeCell({ id: "cell-error", language: "js" });
 
-    const result = await runtime.execute({
-      cell,
-      code: "throw new Error('boom');",
+      const result = await runtime.execute({
+        cell,
+        code: "throw new Error('boom');",
+        notebookId: "notebook-error",
+        env: createEnv(),
+      });
+
+      expect(result.execution.status).toBe("error");
+      const last = result.outputs[result.outputs.length - 1];
+      expect(last?.type).toBe("error");
     });
+  });
 
-    expect(result.execution.status).toBe("error");
-    const last = result.outputs[result.outputs.length - 1];
-    expect(last?.type).toBe("error");
+  it("loads sandboxed dependencies using the installer hook", async () => {
+    await withRuntime(
+      {
+        installDependencies: async (cwd) => {
+          const moduleRoot = join(cwd, "node_modules", "demo-package");
+          await fs.mkdir(moduleRoot, { recursive: true });
+          await fs.writeFile(
+            join(moduleRoot, "package.json"),
+            JSON.stringify({
+              name: "demo-package",
+              version: "1.0.0",
+              main: "index.js",
+            })
+          );
+          await fs.writeFile(
+            join(moduleRoot, "index.js"),
+            "module.exports = () => 'installed-package';\n"
+          );
+        },
+      },
+      async (runtime) => {
+        const cell = createCodeCell({ id: "cell-deps", language: "js" });
+
+        const result = await runtime.execute({
+          cell,
+          code: "const demo = require('demo-package'); demo();",
+          notebookId: "notebook-deps",
+          env: createEnv({ "demo-package": "^1.0.0" }),
+        });
+
+        const display = result.outputs.find(
+          (output) => output.type === "display_data"
+        );
+        expect(display).toBeDefined();
+        const plain = display?.data?.["text/plain"];
+        expect(String(plain)).toContain("installed-package");
+      }
+    );
+  });
+
+  it("restricts fs access to the sandbox directory", async () => {
+    await withRuntime(
+      { installDependencies: async () => {} },
+      async (runtime) => {
+        const cell = createCodeCell({ id: "cell-fs", language: "js" });
+
+        const result = await runtime.execute({
+          cell,
+          code: [
+            "const fs = require('fs');",
+            "try {",
+            "  fs.writeFileSync('/etc/hosts', 'nope');",
+            "  'allowed';",
+            "} catch (error) {",
+            "  error.message;",
+            "}",
+          ].join("\n"),
+          notebookId: "notebook-fs",
+          env: createEnv(),
+        });
+
+        const display = result.outputs.find(
+          (output) => output.type === "display_data"
+        );
+        expect(display).toBeDefined();
+        const message = display?.data?.["text/plain"];
+        expect(String(message)).toContain("not allowed");
+      }
+    );
+  });
+
+  it("sets process.cwd() to the sandbox directory", async () => {
+    await withRuntime(undefined, async (runtime) => {
+      const cell = createCodeCell({ id: "cell-cwd", language: "js" });
+
+      const result = await runtime.execute({
+        cell,
+        code: "process.cwd();",
+        notebookId: "notebook-cwd",
+        env: createEnv(),
+      });
+
+      const display = result.outputs.find(
+        (output) => output.type === "display_data"
+      );
+      expect(display).toBeDefined();
+      const plain = display?.data?.["text/plain"];
+      expect(String(plain)).toContain("notebook-cwd");
+    });
   });
 });

--- a/apps/api/src/kernel/runtime.test.ts
+++ b/apps/api/src/kernel/runtime.test.ts
@@ -4,6 +4,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createCodeCell } from "@nodebooks/notebook-schema";
 import { NotebookRuntime } from "./runtime.js";
+import type {
+  DisplayDataOutput,
+  NotebookOutput,
+} from "@nodebooks/notebook-schema";
+
+const isDisplayData = (output: NotebookOutput): output is DisplayDataOutput =>
+  output.type === "display_data";
 
 const createEnv = (packages: Record<string, string> = {}) => ({
   runtime: "node" as const,
@@ -122,9 +129,7 @@ describe("NotebookRuntime", () => {
           env: createEnv({ "demo-package": "^1.0.0" }),
         });
 
-        const display = result.outputs.find(
-          (output) => output.type === "display_data"
-        );
+        const display = result.outputs.find(isDisplayData);
         expect(display).toBeDefined();
         const plain = display?.data?.["text/plain"];
         expect(String(plain)).toContain("installed-package");
@@ -153,9 +158,7 @@ describe("NotebookRuntime", () => {
           env: createEnv(),
         });
 
-        const display = result.outputs.find(
-          (output) => output.type === "display_data"
-        );
+        const display = result.outputs.find(isDisplayData);
         expect(display).toBeDefined();
         const message = display?.data?.["text/plain"];
         expect(String(message)).toContain("not allowed");
@@ -174,9 +177,7 @@ describe("NotebookRuntime", () => {
         env: createEnv(),
       });
 
-      const display = result.outputs.find(
-        (output) => output.type === "display_data"
-      );
+      const display = result.outputs.find(isDisplayData);
       expect(display).toBeDefined();
       const plain = display?.data?.["text/plain"];
       expect(String(plain)).toContain("notebook-cwd");

--- a/apps/api/src/kernel/runtime.test.ts
+++ b/apps/api/src/kernel/runtime.test.ts
@@ -22,7 +22,10 @@ const withRuntime = async (
   run: (runtime: NotebookRuntime, root: string) => Promise<void>
 ) => {
   const root = await createTempRoot();
-  const runtime = new NotebookRuntime({ ...(options ?? {}), workspaceRoot: root });
+  const runtime = new NotebookRuntime({
+    ...(options ?? {}),
+    workspaceRoot: root,
+  });
   try {
     await run(runtime, root);
   } finally {
@@ -47,9 +50,7 @@ describe("NotebookRuntime", () => {
       });
 
       expect(result.execution.status).toBe("ok");
-      expect(streams.some((line) => line.includes("hello runtime"))).toBe(
-        true
-      );
+      expect(streams.some((line) => line.includes("hello runtime"))).toBe(true);
       expect(
         result.outputs.some((output) => output.type === "display_data")
       ).toBe(true);

--- a/apps/api/src/kernel/runtime.ts
+++ b/apps/api/src/kernel/runtime.ts
@@ -1,10 +1,19 @@
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
-import { formatWithOptions, inspect } from "node:util";
+import fs from "node:fs";
+import { promises as fsPromises } from "node:fs";
+import { createRequire, type NodeRequire } from "node:module";
+import { dirname, join, resolve, sep } from "node:path";
+import { tmpdir } from "node:os";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { formatWithOptions, inspect, promisify } from "node:util";
 import vm from "node:vm";
 import { transform } from "esbuild";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_WORKSPACE_ROOT = join(tmpdir(), "nodebooks-runtime");
 import type {
   CodeCell,
+  NotebookEnv,
   NotebookOutput,
   StreamOutput,
   OutputExecution,
@@ -12,9 +21,19 @@ import type {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
+interface NotebookRuntimeOptions {
+  workspaceRoot?: string;
+  installDependencies?: (
+    cwd: string,
+    packages: Record<string, string>
+  ) => Promise<void>;
+}
+
 interface ExecuteOptions {
   cell: CodeCell;
   code: string;
+  notebookId: string;
+  env: NotebookEnv;
   onStream?: (output: StreamOutput) => void;
   timeoutMs?: number;
 }
@@ -112,15 +131,36 @@ const toDisplayData = (value: unknown) => {
 export class NotebookRuntime {
   private readonly context: vm.Context;
   private readonly console = new RuntimeConsole();
+  private readonly workspaceRoot: string;
+  private readonly installDeps: (
+    cwd: string,
+    packages: Record<string, string>
+  ) => Promise<void>;
+  private readonly processProxy: NodeJS.Process;
+  private sandboxDir: string | null = null;
+  private sandboxRequire: NodeRequire | null = null;
+  private sandboxFs: typeof fs | null = null;
+  private prepareQueue: Promise<void> = Promise.resolve();
+  private currentNotebookId: string | null = null;
+  private currentEnvKey: string | null = null;
 
-  constructor() {
-    const require = createRequire(import.meta.url);
+  constructor(options: NotebookRuntimeOptions = {}) {
+    this.workspaceRoot = options.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT;
+    this.installDeps =
+      options.installDependencies ?? defaultInstallDependencies;
+    fs.mkdirSync(this.workspaceRoot, { recursive: true });
+
+    this.processProxy = createProcessProxy(() =>
+      this.sandboxDir ?? this.workspaceRoot
+    );
+
+    const placeholderRequire = createPlaceholderRequire();
     const sandbox: Record<string, unknown> = {
       console: this.console.proxy,
-      require,
+      require: placeholderRequire,
       module: { exports: {} },
       exports: {},
-      process,
+      process: this.processProxy,
       Buffer,
       setTimeout,
       clearTimeout,
@@ -142,6 +182,8 @@ export class NotebookRuntime {
   async execute({
     cell,
     code,
+    notebookId,
+    env,
     onStream,
     timeoutMs,
   }: ExecuteOptions): Promise<ExecuteResult> {
@@ -156,6 +198,8 @@ export class NotebookRuntime {
     });
 
     try {
+      await this.ensureEnvironment(notebookId, env);
+
       const compiled = await transform(code, {
         loader: cell.language === "ts" ? "ts" : "js",
         format: "cjs",
@@ -163,12 +207,17 @@ export class NotebookRuntime {
         sourcemap: false,
       });
 
-      const filename = join("/notebooks", `${cell.id}.${cell.language}`);
+      if (!this.sandboxDir || !this.sandboxRequire) {
+        throw new Error("Notebook runtime environment is not ready");
+      }
+
+      const filename = join(this.sandboxDir, `${cell.id}.${cell.language}`);
       const module = { exports: {} };
       (this.context as Record<string, unknown>).module = module;
       (this.context as Record<string, unknown>).exports = module.exports;
       (this.context as Record<string, unknown>).__filename = filename;
       (this.context as Record<string, unknown>).__dirname = dirname(filename);
+      (module as Record<string, unknown>).require = this.sandboxRequire;
 
       const script = new vm.Script(compiled.code, {
         filename,
@@ -213,7 +262,419 @@ export class NotebookRuntime {
       this.console.setEmitter(null);
     }
   }
+
+  private async ensureEnvironment(
+    notebookId: string,
+    env: NotebookEnv
+  ): Promise<void> {
+    const packages = sanitizePackages(env.packages ?? {});
+    const envKey = createPackagesKey(packages);
+
+    if (
+      this.currentNotebookId === notebookId &&
+      this.currentEnvKey === envKey &&
+      this.sandboxRequire
+    ) {
+      return;
+    }
+
+    this.prepareQueue = this.prepareQueue.then(async () => {
+      await this.prepareNotebook(notebookId, packages, envKey);
+    });
+
+    await this.prepareQueue;
+  }
+
+  private async prepareNotebook(
+    notebookId: string,
+    packages: Record<string, string>,
+    envKey: string
+  ): Promise<void> {
+    const sandboxDir = join(this.workspaceRoot, notebookId);
+    await fsPromises.mkdir(sandboxDir, { recursive: true });
+
+    const packageJsonPath = join(sandboxDir, "package.json");
+    const entryPath = join(sandboxDir, "__runtime__.cjs");
+    const metadataPath = join(sandboxDir, ".nodebooks-env.json");
+    const nodeModulesPath = join(sandboxDir, "node_modules");
+    const lockfilePath = join(sandboxDir, "package-lock.json");
+
+    const metadata = await readEnvironmentMetadata(metadataPath);
+    const previousKey = metadata?.packagesKey ?? null;
+    const packagesChanged = previousKey !== envKey;
+
+    const packageJson = createPackageJson(notebookId, packages);
+    await fsPromises.writeFile(
+      packageJsonPath,
+      JSON.stringify(packageJson, null, 2)
+    );
+    await ensureEntryModule(entryPath);
+
+    if (Object.keys(packages).length === 0) {
+      await fsPromises.rm(nodeModulesPath, { recursive: true, force: true });
+      await fsPromises.rm(lockfilePath, { force: true });
+      await fsPromises.writeFile(
+        metadataPath,
+        JSON.stringify({ packagesKey: envKey }, null, 2)
+      );
+      this.assignSandboxBindings(sandboxDir);
+      this.currentNotebookId = notebookId;
+      this.currentEnvKey = envKey;
+      return;
+    }
+
+    const hasNodeModules = await pathExists(nodeModulesPath);
+
+    if (packagesChanged || !hasNodeModules) {
+      try {
+        await this.installDeps(sandboxDir, packages);
+      } catch (error) {
+        const message =
+          error && typeof error === "object" && "stderr" in error
+            ? String((error as { stderr?: unknown }).stderr || (error as Error).message)
+            : error instanceof Error
+            ? error.message
+            : "Unknown installation error";
+        throw new Error(
+          `Failed to install notebook dependencies: ${message}`.trim()
+        );
+      }
+    }
+
+    await fsPromises.writeFile(
+      metadataPath,
+      JSON.stringify({ packagesKey: envKey }, null, 2)
+    );
+
+    this.assignSandboxBindings(sandboxDir);
+    this.currentNotebookId = notebookId;
+    this.currentEnvKey = envKey;
+  }
+
+  private assignSandboxBindings(sandboxDir: string) {
+    const sandboxFs = createSandboxFs(sandboxDir);
+    const sandboxRequire = createSandboxRequire(sandboxDir, sandboxFs);
+
+    this.sandboxDir = sandboxDir;
+    this.sandboxFs = sandboxFs;
+    this.sandboxRequire = sandboxRequire;
+
+    const target = this.context as Record<string, unknown>;
+    target.require = sandboxRequire;
+    target.global = this.context;
+    target.globalThis = this.context;
+  }
 }
+
+const sanitizePackages = (packages: Record<string, string>) => {
+  const sanitized: Record<string, string> = {};
+  for (const [rawName, rawVersion] of Object.entries(packages)) {
+    const name = rawName.trim();
+    if (!name) {
+      continue;
+    }
+    const version =
+      typeof rawVersion === "string" && rawVersion.trim().length > 0
+        ? rawVersion.trim()
+        : "latest";
+    sanitized[name] = version;
+  }
+  return sanitized;
+};
+
+const createPackagesKey = (packages: Record<string, string>) => {
+  const entries = Object.keys(packages)
+    .sort()
+    .map((key) => [key, packages[key]]);
+  return JSON.stringify(entries);
+};
+
+const createPackageJson = (
+  notebookId: string,
+  packages: Record<string, string>
+) => {
+  const safeNameBase = notebookId.replace(/[^a-zA-Z0-9_-]/g, "-");
+  const safeName = `notebook-${safeNameBase || "runtime"}`;
+  return {
+    name: safeName,
+    private: true,
+    version: "0.0.0",
+    type: "commonjs",
+    dependencies: packages,
+  };
+};
+
+const readEnvironmentMetadata = async (filePath: string) => {
+  try {
+    const raw = await fsPromises.readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed as { packagesKey?: string };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const ensureEntryModule = async (entryPath: string) => {
+  try {
+    await fsPromises.access(entryPath);
+  } catch {
+    await fsPromises.writeFile(entryPath, "module.exports = {}\n");
+  }
+};
+
+const pathExists = async (filePath: string) => {
+  try {
+    await fsPromises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const createPlaceholderRequire = (): NodeRequire => {
+  const base = createRequire(import.meta.url);
+  const placeholder = ((specifier: string) => {
+    throw new Error("Notebook runtime is not initialized yet");
+  }) as NodeRequire;
+
+  const resolveFn = ((request: string, options?: unknown) => {
+    return base.resolve(request, options as never);
+  }) as NodeRequire["resolve"];
+  if (base.resolve.paths) {
+    resolveFn.paths = base.resolve.paths.bind(base.resolve);
+  }
+
+  placeholder.resolve = resolveFn;
+  placeholder.cache = {};
+  placeholder.extensions = base.extensions;
+  placeholder.main = base.main;
+  return placeholder;
+};
+
+const createSandboxRequire = (
+  root: string,
+  fsModule: typeof fs
+): NodeRequire => {
+  const entry = join(root, "__runtime__.cjs");
+  const base = createRequire(entry);
+
+  const sandboxRequire = ((specifier: string) => {
+    if (specifier === "fs" || specifier === "node:fs") {
+      return fsModule;
+    }
+    if (specifier === "fs/promises" || specifier === "node:fs/promises") {
+      return fsModule.promises;
+    }
+    if (specifier === "child_process" || specifier === "node:child_process") {
+      throw new Error(
+        "Access to child_process is disabled in NodeBooks runtime"
+      );
+    }
+    return base(specifier);
+  }) as NodeRequire;
+
+  const resolveFn = ((request: string, options?: unknown) => {
+    return base.resolve(request, options as never);
+  }) as NodeRequire["resolve"];
+  if (base.resolve.paths) {
+    resolveFn.paths = base.resolve.paths.bind(base.resolve);
+  }
+
+  sandboxRequire.resolve = resolveFn;
+  sandboxRequire.cache = base.cache;
+  sandboxRequire.main = base.main;
+  sandboxRequire.extensions = base.extensions;
+  return sandboxRequire;
+};
+
+const createProcessProxy = (getCwd: () => string): NodeJS.Process => {
+  return new Proxy(process, {
+    get(target, prop, receiver) {
+      if (prop === "cwd") {
+        return () => getCwd();
+      }
+      if (prop === "chdir") {
+        return () => {
+          throw new Error("process.chdir is disabled in NodeBooks runtime");
+        };
+      }
+      if (prop === "exit") {
+        return () => {
+          throw new Error("process.exit is disabled in NodeBooks runtime");
+        };
+      }
+      if (prop === "kill") {
+        return () => {
+          throw new Error("process.kill is disabled in NodeBooks runtime");
+        };
+      }
+
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === "function") {
+        return value.bind(target);
+      }
+      return value;
+    },
+  });
+};
+
+const PATH_ARG_MAP: Record<string, number[]> = {
+  access: [0],
+  accessSync: [0],
+  appendFile: [0],
+  appendFileSync: [0],
+  chmod: [0],
+  chmodSync: [0],
+  chown: [0],
+  chownSync: [0],
+  copyFile: [0, 1],
+  copyFileSync: [0, 1],
+  cp: [0, 1],
+  cpSync: [0, 1],
+  createReadStream: [0],
+  createWriteStream: [0],
+  exists: [0],
+  existsSync: [0],
+  link: [0, 1],
+  linkSync: [0, 1],
+  lstat: [0],
+  lstatSync: [0],
+  mkdir: [0],
+  mkdirSync: [0],
+  mkdtemp: [0],
+  mkdtempSync: [0],
+  open: [0],
+  openSync: [0],
+  opendir: [0],
+  opendirSync: [0],
+  readdir: [0],
+  readdirSync: [0],
+  readFile: [0],
+  readFileSync: [0],
+  readlink: [0],
+  readlinkSync: [0],
+  realpath: [0],
+  realpathSync: [0],
+  rename: [0, 1],
+  renameSync: [0, 1],
+  rm: [0],
+  rmSync: [0],
+  rmdir: [0],
+  rmdirSync: [0],
+  stat: [0],
+  statSync: [0],
+  symlink: [0, 1],
+  symlinkSync: [0, 1],
+  truncate: [0],
+  truncateSync: [0],
+  unlink: [0],
+  unlinkSync: [0],
+  utimes: [0],
+  utimesSync: [0],
+  watch: [0],
+  watchFile: [0],
+  unwatchFile: [0],
+  writeFile: [0],
+  writeFileSync: [0],
+};
+
+const sanitizeFsArgs = (
+  method: string,
+  args: unknown[],
+  root: string
+) => {
+  const indices = PATH_ARG_MAP[method];
+  if (!indices || indices.length === 0) {
+    return args;
+  }
+  const next = [...args];
+  for (const index of indices) {
+    if (index >= next.length) {
+      continue;
+    }
+    next[index] = sanitizePathArgument(root, next[index]);
+  }
+  return next;
+};
+
+const sanitizePathArgument = (root: string, value: unknown) => {
+  if (typeof value === "string") {
+    return ensureWithinRoot(root, value);
+  }
+  if (value instanceof URL) {
+    return ensureWithinRoot(root, fileURLToPath(value));
+  }
+  if (Buffer.isBuffer(value)) {
+    return ensureWithinRoot(root, value.toString());
+  }
+  return value;
+};
+
+const ensureWithinRoot = (root: string, input: string) => {
+  const normalizedRoot = resolve(root);
+  const target = resolve(normalizedRoot, input);
+  if (
+    target === normalizedRoot ||
+    target.startsWith(normalizedRoot + sep)
+  ) {
+    return target;
+  }
+  throw new Error(
+    `Access to path "${input}" is not allowed in this notebook runtime`
+  );
+};
+
+const createSandboxFs = (root: string): typeof fs => {
+  const handler: ProxyHandler<typeof fs> = {
+    get(target, prop, receiver) {
+      if (prop === "promises") {
+        const promisesTarget = target.promises;
+        return new Proxy(promisesTarget, {
+          get(promises, key, receiverPromises) {
+            const value = Reflect.get(promises, key, receiverPromises);
+            if (typeof value !== "function") {
+              return value;
+            }
+            return (...args: unknown[]) => {
+              const sanitized = sanitizeFsArgs(String(key), args, root);
+              return Reflect.apply(value, promises, sanitized);
+            };
+          },
+        });
+      }
+
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+      return (...args: unknown[]) => {
+        const sanitized = sanitizeFsArgs(String(prop), args, root);
+        return Reflect.apply(value, target, sanitized);
+      };
+    },
+  };
+
+  return new Proxy(fs, handler);
+};
+
+const defaultInstallDependencies = async (
+  cwd: string,
+  packages: Record<string, string>
+) => {
+  if (Object.keys(packages).length === 0) {
+    await fsPromises.rm(join(cwd, "node_modules"), { recursive: true, force: true });
+    await fsPromises.rm(join(cwd, "package-lock.json"), { force: true });
+    return;
+  }
+
+  await execFileAsync("npm", ["install", "--no-audit", "--no-fund"], {
+    cwd,
+    env: { ...process.env, npm_config_update_notifier: "false" },
+  });
+};
 
 const withTimeout = async <T>(
   promise: Promise<T>,

--- a/apps/api/src/kernel/runtime.ts
+++ b/apps/api/src/kernel/runtime.ts
@@ -49,18 +49,18 @@ interface ExecuteResult {
 // `class C ...` to `globalThis.C = class C ...`.
 // This allows re-running a cell without "already declared" errors and makes
 // definitions visible to following cells via the shared context.
-const rewriteTopLevelDeclarations = (source: string, lang: "js" | "ts") => {
+const rewriteTopLevelDeclarations = (source: string, _lang: "js" | "ts") => {
   const lines = source.split(/\r?\n/);
   let depth = 0;
   let inBlockComment = false;
   let inString: false | '"' | "'" | "`" = false;
-  let result: string[] = [];
+  const result: string[] = [];
 
   const replaceVar = (line: string) => {
     // handle export prefix
     const exportRe = /^\s*export\s+/;
     const exportPrefix = exportRe.test(line) ? line.match(exportRe)![0] : "";
-    let rest = exportPrefix ? line.slice(exportPrefix.length) : line;
+    const rest = exportPrefix ? line.slice(exportPrefix.length) : line;
     // const/let/var with optional type annotation
     const varRe =
       /^(\s*)(const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=;]+)?\s*=\s*/;
@@ -75,7 +75,7 @@ const rewriteTopLevelDeclarations = (source: string, lang: "js" | "ts") => {
   const replaceFunction = (line: string) => {
     const exportRe = /^\s*export\s+/;
     const exportPrefix = exportRe.test(line) ? line.match(exportRe)![0] : "";
-    let rest = exportPrefix ? line.slice(exportPrefix.length) : line;
+    const rest = exportPrefix ? line.slice(exportPrefix.length) : line;
     const fnRe = /^(\s*)function\s+([A-Za-z_$][\w$]*)\s*\(/;
     const m = rest.match(fnRe);
     if (!m) return null;
@@ -90,7 +90,7 @@ const rewriteTopLevelDeclarations = (source: string, lang: "js" | "ts") => {
   const replaceClass = (line: string) => {
     const exportRe = /^\s*export\s+/;
     const exportPrefix = exportRe.test(line) ? line.match(exportRe)![0] : "";
-    let rest = exportPrefix ? line.slice(exportPrefix.length) : line;
+    const rest = exportPrefix ? line.slice(exportPrefix.length) : line;
     const clsRe = /^(\s*)class\s+([A-Za-z_$][\w$]*)\b/;
     const m = rest.match(clsRe);
     if (!m) return null;
@@ -103,7 +103,7 @@ const rewriteTopLevelDeclarations = (source: string, lang: "js" | "ts") => {
   };
 
   for (let i = 0; i < lines.length; i++) {
-    let line = lines[i];
+    const line = lines[i];
     let j = 0;
     while (j < line.length) {
       const ch = line[j];
@@ -576,7 +576,7 @@ const pathExists = async (filePath: string) => {
 
 const createPlaceholderRequire = (): NodeJS.Require => {
   const base = createRequire(import.meta.url);
-  const placeholder = ((specifier: string) => {
+  const placeholder = ((_specifier: string) => {
     throw new Error("Notebook runtime is not initialized yet");
   }) as unknown as NodeJS.Require;
 

--- a/apps/api/src/routes/dependencies.ts
+++ b/apps/api/src/routes/dependencies.ts
@@ -1,0 +1,144 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { createCodeCell, NotebookSchema } from "@nodebooks/notebook-schema";
+import type { NotebookStore } from "../types.js";
+import { NotebookRuntime } from "../kernel/runtime.js";
+
+const encodePackagePath = (name: string) => {
+  // Encode each path component while preserving slashes
+  return name
+    .split("/")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/");
+};
+
+const resolveVersion = async (name: string, version: string) => {
+  const pkgPath = encodePackagePath(name);
+  const spec = (version || "latest").trim() || "latest";
+  const url = `https://registry.npmjs.org/${pkgPath}/${encodeURIComponent(spec)}`;
+  const res = await fetch(url, { method: "GET" });
+  if (!res.ok) {
+    return null;
+  }
+  const json = (await res.json()) as { version?: string };
+  const resolved = typeof json?.version === "string" ? json.version : null;
+  return resolved;
+};
+
+export const registerDependencyRoutes = (
+  app: FastifyInstance,
+  store: NotebookStore
+) => {
+  app.post("/notebooks/:id/dependencies", async (request, reply) => {
+    const params = z.object({ id: z.string() }).parse(request.params);
+    const body = z
+      .object({ name: z.string().min(1), version: z.string().optional() })
+      .parse(request.body ?? {});
+
+    const notebook = await store.get(params.id);
+    if (!notebook) {
+      reply.code(404);
+      return { error: "Notebook not found" };
+    }
+
+    const resolved = await resolveVersion(body.name, body.version ?? "latest");
+    if (!resolved) {
+      reply.code(400);
+      return {
+        error: `Package ${body.name}@${body.version ?? "latest"} not found`,
+      };
+    }
+
+    const previous = notebook.env.packages;
+    const nextPackages = { ...previous, [body.name]: resolved };
+    const updated = await store.save(
+      NotebookSchema.parse({
+        ...notebook,
+        env: { ...notebook.env, packages: nextPackages },
+      })
+    );
+
+    // Trigger install immediately using a throwaway runtime instance
+    try {
+      const runtime = new NotebookRuntime();
+      const result = await runtime.execute({
+        cell: createCodeCell({ language: "js", source: "" }),
+        code: "",
+        notebookId: updated.id,
+        env: updated.env,
+      });
+      return { data: { env: updated.env, outputs: result.outputs } };
+    } catch (error) {
+      // Roll back env change on failure
+      await store.save(
+        NotebookSchema.parse({
+          ...notebook,
+          env: { ...notebook.env, packages: previous },
+        })
+      );
+      reply.code(500);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to install dependencies";
+      return { error: message };
+    }
+
+    // unreachable; handled above or in catch
+  });
+
+  app.delete("/notebooks/:id/dependencies/:name", async (request, reply) => {
+    const params = z
+      .object({ id: z.string(), name: z.string().min(1) })
+      .parse(request.params);
+
+    const notebook = await store.get(params.id);
+    if (!notebook) {
+      reply.code(404);
+      return { error: "Notebook not found" };
+    }
+
+    if (!(params.name in (notebook.env.packages ?? {}))) {
+      // Nothing to remove, return current env
+      return { data: { env: notebook.env } };
+    }
+
+    const previous = notebook.env.packages;
+    const nextPackages = { ...previous };
+    delete nextPackages[params.name];
+
+    const updated = await store.save(
+      NotebookSchema.parse({
+        ...notebook,
+        env: { ...notebook.env, packages: nextPackages },
+      })
+    );
+
+    try {
+      const runtime = new NotebookRuntime();
+      const result = await runtime.execute({
+        cell: createCodeCell({ language: "js", source: "" }),
+        code: "",
+        notebookId: updated.id,
+        env: updated.env,
+      });
+      return { data: { env: updated.env, outputs: result.outputs } };
+    } catch (error) {
+      // Roll back on failure
+      await store.save(
+        NotebookSchema.parse({
+          ...notebook,
+          env: { ...notebook.env, packages: previous },
+        })
+      );
+      reply.code(500);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to update dependencies";
+      return { error: message };
+    }
+
+    // unreachable; handled above or in catch
+  });
+};

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -9,6 +9,7 @@ import {
 import { InMemorySessionManager } from "./store/memory.js";
 import { SqliteNotebookStore } from "./store/sqlite.js";
 import { registerNotebookRoutes } from "./routes/notebooks.js";
+import { registerDependencyRoutes } from "./routes/dependencies.js";
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerKernelRoutes } from "./kernel/router.js";
 
@@ -55,6 +56,7 @@ export const createServer = async ({
   app.get("/health", async () => ({ status: "ok" }));
 
   registerNotebookRoutes(app, store);
+  registerDependencyRoutes(app, store);
   registerSessionRoutes(app, sessions);
   registerKernelRoutes(app, sessions, store);
 

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -15,7 +15,7 @@ export default function SettingsPage() {
           <div>
             <h3 className="text-sm font-semibold text-slate-900">Theme</h3>
             <p className="text-sm text-slate-500">
-              Dark mode is enabled by default. Light mode toggle coming soon.
+              Light mode is enabled by default. Dark mode toggle coming soon.
             </p>
           </div>
         </CardContent>

--- a/apps/ui/components/NotebookView.tsx
+++ b/apps/ui/components/NotebookView.tsx
@@ -1176,7 +1176,7 @@ const NotebookView = ({ initialNotebookId }: NotebookViewProps) => {
               )}
             </div>
 
-            <div className="space-y-6">
+            <div className="space-y-4">
               {notebook.cells.map((cell, index) => (
                 <CellCard
                   key={cell.id}
@@ -1196,10 +1196,10 @@ const NotebookView = ({ initialNotebookId }: NotebookViewProps) => {
                 />
               ))}
             </div>
-            <div className="mt-10 flex justify-center py-4 opacity-0 transition hover:opacity-100 focus-within:opacity-100">
+            <div className="mt-2 mb-2 flex justify-center py-3 opacity-0 transition hover:opacity-100 focus-within:opacity-100">
               <AddCellMenu
                 onAdd={(type) => handleAddCell(type)}
-                className="pointer-events-auto rounded-full border-slate-300/80 bg-white/95 px-4 py-1 text-xs"
+                className="pointer-events-auto text-[11px]"
               />
             </div>
           </div>

--- a/apps/ui/components/notebook/AddCellMenu.tsx
+++ b/apps/ui/components/notebook/AddCellMenu.tsx
@@ -15,11 +15,10 @@ const AddCellMenu = ({
   return (
     <div
       className={clsx(
-        "flex items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-white px-5 py-2 text-sm text-slate-600 shadow-sm",
+        "flex items-center gap-1 px-1 py-1 text-sm text-slate-600 shadow-sm",
         className
       )}
     >
-      <span className="font-medium">Add cell</span>
       <Button
         variant="outline"
         size="sm"

--- a/apps/ui/components/notebook/AddCellMenu.tsx
+++ b/apps/ui/components/notebook/AddCellMenu.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import clsx from "clsx";
+import { Button } from "../ui/button";
+import { Plus } from "lucide-react";
+import type { NotebookCell } from "@nodebooks/notebook-schema";
+
+const AddCellMenu = ({
+  onAdd,
+  className,
+}: {
+  onAdd: (type: NotebookCell["type"]) => void;
+  className?: string;
+}) => {
+  return (
+    <div
+      className={clsx(
+        "flex items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-white px-5 py-2 text-sm text-slate-600 shadow-sm",
+        className
+      )}
+    >
+      <span className="font-medium">Add cell</span>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-2"
+        onClick={() => onAdd("markdown")}
+      >
+        <Plus className="h-4 w-4" />
+        Markdown
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-2"
+        onClick={() => onAdd("code")}
+      >
+        <Plus className="h-4 w-4" />
+        Code
+      </Button>
+    </div>
+  );
+};
+
+export default AddCellMenu;

--- a/apps/ui/components/notebook/CellCard.tsx
+++ b/apps/ui/components/notebook/CellCard.tsx
@@ -43,15 +43,14 @@ const AddCellMenu = ({
   return (
     <div
       className={clsx(
-        "flex items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-white px-5 py-2 text-sm text-slate-600 shadow-sm",
+        "flex items-center gap-1 text-xs text-slate-600 shadow-sm",
         className
       )}
     >
-      <span className="font-medium">Add cell</span>
       <Button
         variant="outline"
         size="sm"
-        className="gap-2"
+        className="h-7 px-2 text-xs gap-1"
         onClick={() => onAdd("markdown")}
       >
         <Plus className="h-4 w-4" />
@@ -60,7 +59,7 @@ const AddCellMenu = ({
       <Button
         variant="outline"
         size="sm"
-        className="gap-2"
+        className="h-7 px-2 text-xs gap-1"
         onClick={() => onAdd("code")}
       >
         <Plus className="h-4 w-4" />
@@ -208,11 +207,8 @@ const CellCard = ({
         />
       )}
 
-      <div className="flex justify-center pt-4 opacity-0 transition pointer-events-none group-hover/cell:opacity-100 group-hover/cell:pointer-events-auto group-focus-within/cell:opacity-100 group-focus-within/cell:pointer-events-auto">
-        <AddCellMenu
-          onAdd={onAddBelow}
-          className="rounded-full border-slate-300/80 bg-white/95 px-4 py-1 text-xs"
-        />
+      <div className="flex justify-center pt-2 opacity-0 transition pointer-events-none group-hover/cell:opacity-100 group-hover/cell:pointer-events-auto group-focus-within/cell:opacity-100 group-focus-within/cell:pointer-events-auto">
+        <AddCellMenu onAdd={onAddBelow} className="px-1 py-1text-[11px]" />
       </div>
     </article>
   );

--- a/apps/ui/components/notebook/CodeCellView.tsx
+++ b/apps/ui/components/notebook/CodeCellView.tsx
@@ -111,13 +111,13 @@ const CodeCellView = ({
       ) : null}
 
       {(hideEditor || cell.outputs.length > 0) && (
-        <div className="space-y-2 border-t border-slate-800 bg-slate-900/60 p-4 text-sm text-emerald-100">
+        <div className="space-y-2 border-t border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-100">
           {cell.outputs.length > 0 ? (
             cell.outputs.map((output, index) => (
               <OutputView key={index} output={output} />
             ))
           ) : (
-            <div className="flex items-center gap-2 text-emerald-200/80">
+            <div className="flex items-center gap-2 text-slate-300/80">
               <Loader2 className="h-3.5 w-3.5 animate-spin" /> Preparing
               environment…
             </div>

--- a/apps/ui/components/notebook/CodeCellView.tsx
+++ b/apps/ui/components/notebook/CodeCellView.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import type { OnMount } from "@monaco-editor/react";
+import MonacoEditor from "./MonacoEditorClient";
+import type { NotebookCell } from "@nodebooks/notebook-schema";
+import { Badge } from "../ui/badge";
+import { Loader2 } from "lucide-react";
+import OutputView from "./OutputView";
+
+interface CodeCellViewProps {
+  cell: Extract<NotebookCell, { type: "code" }>;
+  onChange: (updater: (cell: NotebookCell) => NotebookCell) => void;
+  onRun: () => void;
+  isRunning: boolean;
+  editorKey: string;
+}
+
+const CodeCellView = ({
+  cell,
+  onChange,
+  onRun,
+  isRunning,
+  editorKey,
+}: CodeCellViewProps) => {
+  const runShortcutRef = useRef(onRun);
+
+  useEffect(() => {
+    runShortcutRef.current = onRun;
+  }, [onRun]);
+
+  const handleEditorMount = useCallback<OnMount>((editor, monaco) => {
+    const run = () => runShortcutRef.current();
+    editor.addAction({
+      id: "nodebooks.run-cell",
+      label: "Run Cell",
+      keybindings: [
+        monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+        monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+      ],
+      run,
+    });
+    editor.onDidFocusEditorWidget?.((): void => {
+      const el = editor.getDomNode?.();
+      if (el) {
+        const article = el.closest(
+          "article[id^='cell-']"
+        ) as HTMLElement | null;
+        if (article?.id?.startsWith("cell-")) {
+          try {
+            article.dispatchEvent(new Event("focus", { bubbles: true }));
+          } catch {
+            /* noop */
+          }
+        }
+      }
+    });
+  }, []);
+
+  const hideEditor = Boolean(
+    (cell.metadata as { display?: { hideEditor?: boolean } })?.display
+      ?.hideEditor
+  );
+  const title =
+    (cell.metadata as { display?: { title?: string } })?.display?.title ??
+    undefined;
+
+  return (
+    <div className="relative rounded-2xl bg-slate-950 text-slate-100 shadow-lg ring-1 ring-slate-900/60">
+      <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
+        {title ? (
+          <Badge variant="outline" className="px-2 py-0.5 text-[10px]">
+            {title}
+          </Badge>
+        ) : null}
+        <Badge
+          variant="secondary"
+          className="px-2 py-0.5 text-[10px] tracking-wide"
+        >
+          {cell.language.toUpperCase()}
+        </Badge>
+      </div>
+
+      {!hideEditor ? (
+        <div className="overflow-hidden rounded-2xl">
+          <MonacoEditor
+            key={editorKey}
+            path={`${cell.id}.${cell.language === "ts" ? "ts" : "js"}`}
+            height="260px"
+            defaultLanguage={
+              cell.language === "ts" ? "typescript" : "javascript"
+            }
+            language={cell.language === "ts" ? "typescript" : "javascript"}
+            theme="vs-dark"
+            value={cell.source}
+            onChange={(value) =>
+              onChange(() => ({ ...cell, source: value ?? "" }))
+            }
+            onMount={handleEditorMount}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 14,
+              lineNumbers: "on",
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+              readOnly: isRunning,
+              padding: { top: 18, bottom: 18 },
+            }}
+          />
+        </div>
+      ) : null}
+
+      {(hideEditor || cell.outputs.length > 0) && (
+        <div className="space-y-2 border-t border-slate-800 bg-slate-900/60 p-4 text-sm text-emerald-100">
+          {cell.outputs.length > 0 ? (
+            cell.outputs.map((output, index) => (
+              <OutputView key={index} output={output} />
+            ))
+          ) : (
+            <div className="flex items-center gap-2 text-emerald-200/80">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Preparing
+              environment…
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-end border-t border-slate-800 px-4 py-2 text-xs uppercase tracking-[0.2em] text-slate-400">
+        {isRunning ? (
+          <span className="flex items-center gap-2 text-amber-400">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Running…
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default CodeCellView;

--- a/apps/ui/components/notebook/MarkdownCellView.tsx
+++ b/apps/ui/components/notebook/MarkdownCellView.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import type { OnMount } from "@monaco-editor/react";
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+import MonacoEditor from "./MonacoEditorClient";
+import type { NotebookCell } from "@nodebooks/notebook-schema";
+
+interface MarkdownCellViewProps {
+  cell: Extract<NotebookCell, { type: "markdown" }>;
+  onChange: (updater: (cell: NotebookCell) => NotebookCell) => void;
+  editorKey: string;
+}
+
+const MarkdownCellView = ({
+  cell,
+  onChange,
+  editorKey,
+}: MarkdownCellViewProps) => {
+  const html = useMemo(() => {
+    const parsed = marked.parse(cell.source ?? "", { async: false });
+    const rendered = typeof parsed === "string" ? parsed : "";
+    return DOMPurify.sanitize(rendered);
+  }, [cell.source]);
+
+  type MarkdownUIMeta = { ui?: { edit?: boolean } };
+  const isEditing = (cell.metadata as MarkdownUIMeta).ui?.edit ?? true;
+
+  const setEdit = useCallback(
+    (edit: boolean) => {
+      onChange((current) => {
+        if (current.type !== "markdown") return current;
+        const next: NotebookCell = {
+          ...current,
+          metadata: {
+            ...current.metadata,
+            ui: { ...((current.metadata as MarkdownUIMeta).ui ?? {}), edit },
+          },
+        };
+        return next;
+      });
+    },
+    [onChange]
+  );
+
+  const handleMount = useCallback<OnMount>(
+    (editor, monaco) => {
+      editor.addAction({
+        id: "nodebooks.md.done",
+        label: "Done Editing",
+        keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Enter],
+        run: () => {
+          editor.trigger("keyboard", "editor.action.formatDocument", undefined);
+          setEdit(false);
+        },
+      });
+    },
+    [setEdit]
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {isEditing ? (
+        <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-transparent">
+          <MonacoEditor
+            key={editorKey}
+            path={`${cell.id}.md`}
+            height="220px"
+            language="markdown"
+            defaultLanguage="markdown"
+            theme="vs-dark"
+            value={cell.source}
+            onMount={handleMount}
+            onChange={(value) =>
+              onChange(() => ({ ...cell, source: value ?? "" }))
+            }
+            options={{
+              minimap: { enabled: false },
+              fontSize: 14,
+              lineNumbers: "off",
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+              padding: { top: 12, bottom: 12 },
+            }}
+          />
+          <div
+            className="markdown-preview space-y-3 border-t border-slate-200 p-5 text-sm leading-7 text-slate-700"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </div>
+      ) : (
+        <div className="relative">
+          <div
+            className="markdown-preview space-y-3 rounded-xl border border-transparent p-5 text-sm leading-7 text-slate-700 transition group-hover/cell:border-slate-200"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MarkdownCellView;

--- a/apps/ui/components/notebook/MonacoEditorClient.tsx
+++ b/apps/ui/components/notebook/MonacoEditorClient.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const MonacoEditor = dynamic(
+  async () => {
+    const mod = await import("@monaco-editor/react");
+    return mod.default;
+  },
+  { ssr: false }
+);
+
+export default MonacoEditor;

--- a/apps/ui/components/notebook/OutlinePanel.tsx
+++ b/apps/ui/components/notebook/OutlinePanel.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import clsx from "clsx";
+import { Button } from "../ui/button";
+import type { OutlineItem } from "./types";
+
+interface OutlinePanelProps {
+  items: OutlineItem[];
+  onSelect: (cellId: string) => void;
+  activeCellId?: string;
+}
+
+const OutlinePanel = ({ items, onSelect, activeCellId }: OutlinePanelProps) => {
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+          Outline
+        </p>
+      </div>
+      {items.length === 0 ? (
+        <p className="text-xs text-slate-500">
+          Add headings to your Markdown cells to build an outline.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {items.map((item) => (
+            <li key={item.id}>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={clsx(
+                  "w-full justify-start text-sm",
+                  activeCellId === item.cellId
+                    ? "bg-slate-100 text-slate-900"
+                    : "text-slate-500 hover:text-slate-900"
+                )}
+                style={{ paddingLeft: 12 + (item.level - 1) * 12 }}
+                onClick={() => onSelect(item.cellId)}
+              >
+                {item.title}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default OutlinePanel;

--- a/apps/ui/components/notebook/OutputView.tsx
+++ b/apps/ui/components/notebook/OutputView.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { NotebookOutput } from "@nodebooks/notebook-schema";
+
+const OutputView = ({ output }: { output: NotebookOutput }) => {
+  if (output.type === "stream") {
+    return (
+      <pre className="whitespace-pre-wrap font-mono text-emerald-100">
+        <span className="text-emerald-300">[{output.name}]</span> {output.text}
+      </pre>
+    );
+  }
+
+  if (output.type === "error") {
+    return (
+      <div className="rounded-lg border border-rose-400 bg-rose-100/80 p-3 font-mono text-sm text-rose-700">
+        <strong>{output.ename}:</strong> {output.evalue}
+        {output.traceback.length > 0 && (
+          <pre className="mt-2 whitespace-pre-wrap text-xs">
+            {output.traceback.join("\n")}
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-800/90 p-3">
+      <pre className="whitespace-pre-wrap text-xs text-slate-100">
+        {JSON.stringify(output.data, null, 2)}
+      </pre>
+    </div>
+  );
+};
+
+export default OutputView;

--- a/apps/ui/components/notebook/SetupPanel.tsx
+++ b/apps/ui/components/notebook/SetupPanel.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useMemo } from "react";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Trash2 } from "lucide-react";
+import type { Notebook } from "@nodebooks/notebook-schema";
+
+interface SetupPanelProps {
+  env: Notebook["env"];
+  onRemoveDependency: (name: string) => Promise<void> | void;
+}
+
+const SetupPanel = ({ env, onRemoveDependency }: SetupPanelProps) => {
+  const dependencies = useMemo(
+    () =>
+      Object.entries(env.packages ?? {})
+        .filter(([name]) => name.trim().length > 0)
+        .map(([name, version]) => ({ name, version: String(version ?? "") })),
+    [env.packages]
+  );
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+          Environment
+        </p>
+        <div className="mt-1">
+          <Badge variant="secondary" className="uppercase tracking-[0.2em]">
+            {env.runtime.toUpperCase()} {env.version}
+          </Badge>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {dependencies.length === 0 ? (
+          <p className="text-xs text-slate-500">No dependencies added yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {dependencies.map((d) => (
+              <DependencyRow
+                key={d.name}
+                name={d.name}
+                version={d.version}
+                onRemove={() => void onRemoveDependency(d.name)}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface DependencyRowProps {
+  name: string;
+  version?: string;
+  onRemove: () => void;
+}
+
+const DependencyRow = ({ name, version, onRemove }: DependencyRowProps) => {
+  return (
+    <li className="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2">
+      <div className="flex-1 truncate text-sm text-slate-700">{name}</div>
+      <Badge variant="secondary" className="font-mono text-[11px]">
+        {version || "latest"}
+      </Badge>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="text-rose-600 hover:text-rose-700"
+        onClick={onRemove}
+        aria-label={`Remove ${name}`}
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </li>
+  );
+};
+
+export default SetupPanel;

--- a/apps/ui/components/notebook/types.ts
+++ b/apps/ui/components/notebook/types.ts
@@ -1,0 +1,19 @@
+export interface NotebookSessionSummary {
+  id: string;
+  notebookId: string;
+  createdAt: string;
+  status: "open" | "closed";
+}
+
+export type NotebookTemplateId = "starter" | "typescript" | "blank";
+
+export interface OutlineItem {
+  id: string;
+  cellId: string;
+  title: string;
+  level: number;
+}
+
+export interface NotebookViewProps {
+  initialNotebookId?: string;
+}

--- a/apps/ui/components/notebook/utils.ts
+++ b/apps/ui/components/notebook/utils.ts
@@ -1,0 +1,68 @@
+import type { Notebook } from "@nodebooks/notebook-schema";
+import type { OutlineItem } from "./types";
+
+export const formatTimestamp = (value: string) => {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+};
+
+export const parseDependencySpecifier = (raw: string) => {
+  const value = raw.trim();
+  if (!value) {
+    return null;
+  }
+  if (value.startsWith("@")) {
+    const slashIndex = value.indexOf("/");
+    if (slashIndex === -1) {
+      return { name: value, version: "latest" };
+    }
+    const atIndex = value.indexOf("@", slashIndex + 1);
+    if (atIndex === -1) {
+      return { name: value, version: "latest" };
+    }
+    const name = value.slice(0, atIndex).trim();
+    const version = value.slice(atIndex + 1).trim() || "latest";
+    return name ? { name, version } : null;
+  }
+  const lastAt = value.lastIndexOf("@");
+  if (lastAt > 0) {
+    const name = value.slice(0, lastAt).trim();
+    const version = value.slice(lastAt + 1).trim() || "latest";
+    return name ? { name, version } : null;
+  }
+  return { name: value, version: "latest" };
+};
+
+export const parseMultipleDependencies = (raw: string) => {
+  const items = String(raw)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((token) => parseDependencySpecifier(token))
+    .filter((x): x is { name: string; version: string } => Boolean(x));
+  return items;
+};
+
+export const buildOutlineItems = (notebook: Notebook | null | undefined) => {
+  if (!notebook) return [] as OutlineItem[];
+  const items: OutlineItem[] = [];
+  notebook.cells.forEach((cell) => {
+    if (cell.type !== "markdown" || !cell.source) return;
+    const lines = cell.source.split("\n");
+    lines.forEach((line, index) => {
+      const match = /^(#{1,4})\s+(.*)/.exec(line.trim());
+      if (match) {
+        items.push({
+          id: `${cell.id}-${index}`,
+          cellId: cell.id,
+          title: match[2].trim(),
+          level: match[1].length,
+        });
+      }
+    });
+  });
+  return items;
+};

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -12,9 +12,10 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "@nodebooks/notebook-schema": "workspace:*",
-    "lucide-react": "^0.469.0",
+    "ansi-to-html": "^0.7.2",
     "clsx": "^2.1.1",
     "dompurify": "^3.2.7",
+    "lucide-react": "^0.469.0",
     "marked": "^16.3.0",
     "monaco-editor": "^0.53.0",
     "next": "^15.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)
+        version: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0)(lightningcss@1.30.1)(tsx@4.20.5)
 
   apps/ui:
     dependencies:
@@ -84,6 +84,9 @@ importers:
       '@nodebooks/notebook-schema':
         specifier: workspace:*
         version: link:../../packages/notebook-schema
+      ansi-to-html:
+        specifier: ^0.7.2
+        version: 0.7.2
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -150,7 +153,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)
+        version: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0)(lightningcss@1.30.1)(tsx@4.20.5)
 
   packages/notebook-schema:
     dependencies:
@@ -169,7 +172,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)
+        version: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0)(lightningcss@1.30.1)(tsx@4.20.5)
 
 packages:
 
@@ -1165,6 +1168,11 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-to-html@0.7.2:
+    resolution: {integrity: sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1429,6 +1437,9 @@ packages:
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  entities@2.2.0:
+    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -3696,6 +3707,10 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-to-html@0.7.2:
+    dependencies:
+      entities: 2.2.0
+
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
@@ -3991,6 +4006,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.2.3
 
+  entities@2.2.0: {}
+
   entities@6.0.1: {}
 
   es-abstract@1.24.0:
@@ -4137,8 +4154,8 @@ snapshots:
       '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.36.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.36.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.36.0(jiti@2.5.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.36.0(jiti@2.5.1))
@@ -4157,7 +4174,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4168,22 +4185,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.36.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.36.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4194,7 +4211,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.36.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1)))(eslint@9.36.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.36.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5600,7 +5617,7 @@ snapshots:
       lightningcss: 1.30.1
       tsx: 4.20.5
 
-  vitest@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5):
+  vitest@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0)(lightningcss@1.30.1)(tsx@4.20.5):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4


### PR DESCRIPTION
## Summary
- provision a per-notebook workspace that installs requested npm packages and exposes a sandboxed require/fs in the kernel runtime
- add coverage for dependency resolution, filesystem restrictions, and sandbox cwd handling in runtime tests
- surface a setup sidebar in the notebook UI to manage dependencies with add/edit/remove flows

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cf4d9bd230832d919caa60039b2923