### PR TITLE
feat: update notebooks toolbar and improve auto-save

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,22 @@ Use `pnpm@10` (declared in `package.json`) to install dependencies across the mo
 
 TypeScript with ES modules is the default; keep files as `.ts`/`.tsx`. Favor 2-space indentation and double quotes to match existing code. Prettier is configured at the repo root (`.prettierrc`) with `.prettierignore` excluding build output and `apps/backend/data`; run `pnpm format` before committing. Import types using `import type` (ESLint enforces `@typescript-eslint/consistent-type-imports`). Name React components in `PascalCase`, utility modules in `camelCase`, and tests as `*.test.ts[x]`.
 
+## React useEffect Guidelines
+
+**Before using `useEffect`, read:** [You might not need useEffect](https://react.dev/learn/you-might-not-need-an-effect).
+
+Common cases where `useEffect` is NOT needed:
+
+- Transforming data for rendering (use variables or useMemo instead)
+- Handling user events (use event handlers instead)
+- Resetting state when props change (use key prop or calculate during render)
+- Updating state based on props/state changes (calculate during render)
+
+Only use `useEffect` for:
+
+- Synchronizing with external systems (APIs, DOM, third-party libraries)
+- Cleanup that must happen when the component unmounts
+
 ## Testing Guidelines
 
 Vitest is configured per workspace (Node environment for backend and schema, JSDOM for the UI). Place backend and schema tests alongside code in `src/**/*.test.ts`; UI smoke and component tests live under `apps/client/tests/`. Run focused suites with `pnpm --filter <workspace> test`. When adding logic, extend coverage by asserting error paths and WebSocket interactions; prefer deterministic fixtures over the bundled SQLite file.

--- a/apps/backend/src/routes/dependencies.ts
+++ b/apps/backend/src/routes/dependencies.ts
@@ -1,6 +1,10 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { createCodeCell, NotebookSchema } from "@nodebooks/notebook-schema";
+import {
+  createCodeCell,
+  ensureNotebookRuntimeVersion,
+  NotebookSchema,
+} from "@nodebooks/notebook-schema";
 import type { NotebookStore } from "../types.js";
 import { NotebookRuntime } from "../kernel/runtime.js";
 
@@ -52,10 +56,12 @@ export const registerDependencyRoutes = (
     const previous = notebook.env.packages;
     const nextPackages = { ...previous, [body.name]: resolved };
     const updated = await store.save(
-      NotebookSchema.parse({
-        ...notebook,
-        env: { ...notebook.env, packages: nextPackages },
-      })
+      ensureNotebookRuntimeVersion(
+        NotebookSchema.parse({
+          ...notebook,
+          env: { ...notebook.env, packages: nextPackages },
+        })
+      )
     );
 
     // Trigger install immediately using a throwaway runtime instance
@@ -71,10 +77,12 @@ export const registerDependencyRoutes = (
     } catch (error) {
       // Roll back env change on failure
       await store.save(
-        NotebookSchema.parse({
-          ...notebook,
-          env: { ...notebook.env, packages: previous },
-        })
+        ensureNotebookRuntimeVersion(
+          NotebookSchema.parse({
+            ...notebook,
+            env: { ...notebook.env, packages: previous },
+          })
+        )
       );
       reply.code(500);
       const message =
@@ -108,10 +116,12 @@ export const registerDependencyRoutes = (
     delete nextPackages[params.name];
 
     const updated = await store.save(
-      NotebookSchema.parse({
-        ...notebook,
-        env: { ...notebook.env, packages: nextPackages },
-      })
+      ensureNotebookRuntimeVersion(
+        NotebookSchema.parse({
+          ...notebook,
+          env: { ...notebook.env, packages: nextPackages },
+        })
+      )
     );
 
     try {
@@ -126,10 +136,12 @@ export const registerDependencyRoutes = (
     } catch (error) {
       // Roll back on failure
       await store.save(
-        NotebookSchema.parse({
-          ...notebook,
-          env: { ...notebook.env, packages: previous },
-        })
+        ensureNotebookRuntimeVersion(
+          NotebookSchema.parse({
+            ...notebook,
+            env: { ...notebook.env, packages: previous },
+          })
+        )
       );
       reply.code(500);
       const message =

--- a/apps/backend/src/store/memory.ts
+++ b/apps/backend/src/store/memory.ts
@@ -1,5 +1,6 @@
 import {
   createEmptyNotebook,
+  ensureNotebookRuntimeVersion,
   NotebookSchema,
   type Notebook,
 } from "@nodebooks/notebook-schema";
@@ -17,15 +18,19 @@ export class InMemoryNotebookStore implements NotebookStore {
 
   constructor(initialNotebooks: Notebook[] = []) {
     initialNotebooks.forEach((notebook) => {
-      const parsed = NotebookSchema.parse(notebook);
+      const parsed = ensureNotebookRuntimeVersion(
+        NotebookSchema.parse(notebook)
+      );
       this.notebooks.set(parsed.id, parsed);
     });
 
     if (this.notebooks.size === 0) {
-      const sample = createEmptyNotebook({
-        name: "Welcome to NodeBooks",
-        cells: [],
-      });
+      const sample = ensureNotebookRuntimeVersion(
+        createEmptyNotebook({
+          name: "Welcome to NodeBooks",
+          cells: [],
+        })
+      );
       this.notebooks.set(sample.id, sample);
     }
   }
@@ -39,10 +44,12 @@ export class InMemoryNotebookStore implements NotebookStore {
   }
 
   async save(notebook: Notebook): Promise<Notebook> {
-    const parsed = NotebookSchema.parse({
-      ...notebook,
-      updatedAt: new Date().toISOString(),
-    });
+    const parsed = ensureNotebookRuntimeVersion(
+      NotebookSchema.parse({
+        ...notebook,
+        updatedAt: new Date().toISOString(),
+      })
+    );
     this.notebooks.set(parsed.id, parsed);
     return parsed;
   }

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -4,9 +4,24 @@ import { Inter } from "next/font/google";
 
 const inter = Inter({ subsets: ["latin"] });
 
+const BASE_DESCRIPTION = "Interactive Node.js Notebooks";
+
 export const metadata: Metadata = {
-  title: "NodeBooks",
-  description: "Interactive Node.js Notebooks",
+  title: {
+    default: "NodeBooks",
+    template: "%s · NodeBooks",
+  },
+  description: BASE_DESCRIPTION,
+  openGraph: {
+    title: "NodeBooks",
+    description: BASE_DESCRIPTION,
+    siteName: "NodeBooks",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "NodeBooks",
+    description: BASE_DESCRIPTION,
+  },
   icons: {
     icon: "/icon.svg",
     shortcut: "/icon.svg",

--- a/apps/client/app/notebooks/[id]/page.tsx
+++ b/apps/client/app/notebooks/[id]/page.tsx
@@ -1,9 +1,75 @@
-"use client";
-
+import type { Metadata } from "next";
 import NotebookView from "../../../components/NotebookView";
-import { useParams } from "next/navigation";
 
-export default function NotebookEditorPage() {
-  const params = useParams<{ id: string }>();
-  return <NotebookView initialNotebookId={params.id} />;
+interface NotebookPageProps {
+  params: Promise<{ id: string }>;
 }
+
+const buildNotebookApiUrl = (id: string): string => {
+  const rawBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (rawBase && /^https?:\/\//.test(rawBase)) {
+    const normalized = rawBase.endsWith("/") ? rawBase.slice(0, -1) : rawBase;
+    return `${normalized}/notebooks/${id}`;
+  }
+
+  const fallback = rawBase ?? "/api";
+  const trimmed = fallback.endsWith("/") ? fallback.slice(0, -1) : fallback;
+  if (!trimmed || trimmed === "/") {
+    return `/notebooks/${id}`;
+  }
+  if (trimmed.startsWith("/")) {
+    return `${trimmed}/notebooks/${id}`;
+  }
+  return `/${trimmed}/notebooks/${id}`;
+};
+
+export const generateMetadata = async ({
+  params,
+}: NotebookPageProps): Promise<Metadata> => {
+  const fallbackTitle = "Notebook";
+  let notebookTitle: string | null = null;
+  const { id } = await params;
+
+  try {
+    const response = await fetch(buildNotebookApiUrl(id), {
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    if (response.ok) {
+      const payload = await response.json();
+      const name = payload?.data?.name;
+      if (typeof name === "string" && name.trim().length > 0) {
+        notebookTitle = name.trim();
+      }
+    }
+  } catch {
+    // Metadata should never block rendering; fall back to defaults when the API is unavailable.
+  }
+
+  const title = notebookTitle ?? fallbackTitle;
+  const fullTitle = notebookTitle
+    ? `${notebookTitle} · NodeBooks`
+    : "NodeBooks";
+  const description = notebookTitle
+    ? `Notebook ${notebookTitle} in NodeBooks.`
+    : "Interactive Node.js Notebooks.";
+
+  return {
+    title,
+    openGraph: {
+      title: fullTitle,
+      description,
+    },
+    twitter: {
+      title: fullTitle,
+      description,
+    },
+  };
+};
+
+const NotebookEditorPage = async ({ params }: NotebookPageProps) => {
+  const { id } = await params;
+  return <NotebookView initialNotebookId={id} />;
+};
+
+export default NotebookEditorPage;

--- a/apps/client/components/AppShell.tsx
+++ b/apps/client/components/AppShell.tsx
@@ -191,15 +191,19 @@ const AppShell = ({
             })}
           </nav>
         </div>
-        <div className={cn("px-2 pb-4", collapsed && "px-1")}>
+        <div
+          className={cn("px-2 pb-4", collapsed && "px-1 flex justify-center")}
+        >
           <Button
             className={cn(
-              "w-full gap-2",
-              collapsed ? "justify-center h-9" : "justify-center h-9"
+              collapsed ? "h-9 w-9 p-0" : "h-9 w-full justify-center gap-2"
             )}
+            size={collapsed ? "icon" : "md"}
             variant="secondary"
             type="button"
             onClick={onNewNotebook}
+            aria-label="Create new notebook"
+            title="Create new notebook"
           >
             <Plus className="h-4 w-4" />
             {!collapsed && <span className="text-sm">New Notebook</span>}

--- a/apps/client/components/notebook/CellCard.tsx
+++ b/apps/client/components/notebook/CellCard.tsx
@@ -19,7 +19,10 @@ import MarkdownCellView from "./MarkdownCellView";
 
 interface CellCardProps {
   cell: NotebookCell;
-  onChange: (updater: (cell: NotebookCell) => NotebookCell) => void;
+  onChange: (
+    updater: (cell: NotebookCell) => NotebookCell,
+    options?: { persist?: boolean; touch?: boolean }
+  ) => void;
   onRun: () => void;
   onDelete: () => void;
   onAddBelow: (type: NotebookCell["type"]) => void;
@@ -139,19 +142,21 @@ const CellCard = ({
             variant="ghost"
             size="icon"
             onClick={() =>
-              onChange((current) => {
-                if (current.type !== "markdown") return current;
-                type U = { ui?: { edit?: boolean } };
-                const ui = (current.metadata as U).ui ?? {};
-                const next = {
-                  ...current,
-                  metadata: {
-                    ...current.metadata,
-                    ui: { ...ui, edit: !ui.edit },
-                  },
-                } as NotebookCell;
-                return next;
-              })
+              onChange(
+                (current) => {
+                  if (current.type !== "markdown") return current;
+                  type U = { ui?: { edit?: boolean } };
+                  const ui = (current.metadata as U).ui ?? {};
+                  return {
+                    ...current,
+                    metadata: {
+                      ...current.metadata,
+                      ui: { ...ui, edit: !ui.edit },
+                    },
+                  } as NotebookCell;
+                },
+                mdEditing ? { persist: true } : undefined
+              )
             }
             aria-label="Toggle edit markdown"
             title="Toggle edit markdown"

--- a/apps/client/components/notebook/CodeCellView.tsx
+++ b/apps/client/components/notebook/CodeCellView.tsx
@@ -10,7 +10,10 @@ import OutputView from "./OutputView";
 
 interface CodeCellViewProps {
   cell: Extract<NotebookCell, { type: "code" }>;
-  onChange: (updater: (cell: NotebookCell) => NotebookCell) => void;
+  onChange: (
+    updater: (cell: NotebookCell) => NotebookCell,
+    options?: { persist?: boolean; touch?: boolean }
+  ) => void;
   onRun: () => void;
   isRunning: boolean;
   editorKey: string;


### PR DESCRIPTION
This pull request introduces several improvements and important changes to both the backend and frontend of the NodeBooks application. The main focus is on ensuring that all notebook objects have a consistent runtime version by using the new `ensureNotebookRuntimeVersion` utility throughout the backend, improving notebook metadata and accessibility in the frontend, and adding new UI controls. Additionally, documentation has been updated to provide clear guidelines for React `useEffect` usage.

**Backend: Consistent Notebook Runtime Version**

* Applied `ensureNotebookRuntimeVersion` when saving, loading, or initializing notebooks across all storage backends (`memory`, `sqlite`, `postgres`) and API routes to guarantee all notebooks have a runtime version, improving data consistency and future migrations. [[1]](diffhunk://#diff-fc9cb31e3adff476d97b8cb276be582d796c497443811499b44c4c277c29999eL3-R7) [[2]](diffhunk://#diff-fc9cb31e3adff476d97b8cb276be582d796c497443811499b44c4c277c29999eR59-R64) [[3]](diffhunk://#diff-fc9cb31e3adff476d97b8cb276be582d796c497443811499b44c4c277c29999eR80-R85) [[4]](diffhunk://#diff-fc9cb31e3adff476d97b8cb276be582d796c497443811499b44c4c277c29999eR119-R124) [[5]](diffhunk://#diff-fc9cb31e3adff476d97b8cb276be582d796c497443811499b44c4c277c29999eR139-R144) [[6]](diffhunk://#diff-6c56063130d036fb50416720c1053f617ba9613dac3b18cf04c58cc7c9118a9dR7-R12) [[7]](diffhunk://#diff-6c56063130d036fb50416720c1053f617ba9613dac3b18cf04c58cc7c9118a9dR28-R38) [[8]](diffhunk://#diff-6c56063130d036fb50416720c1053f617ba9613dac3b18cf04c58cc7c9118a9dL44-R50) [[9]](diffhunk://#diff-6c56063130d036fb50416720c1053f617ba9613dac3b18cf04c58cc7c9118a9dL83-R98) [[10]](diffhunk://#diff-6c56063130d036fb50416720c1053f617ba9613dac3b18cf04c58cc7c9118a9dL105-R120) [[11]](diffhunk://#diff-6c56063130d036fb50416720c1053f617ba9613dac3b18cf04c58cc7c9118a9dL123-R131) [[12]](diffhunk://#diff-f7aa54836a25983018908dbfc69592ae1d524e6a20e8bf26b03213644285c2f0R3) [[13]](diffhunk://#diff-f7aa54836a25983018908dbfc69592ae1d524e6a20e8bf26b03213644285c2f0L20-R33) [[14]](diffhunk://#diff-f7aa54836a25983018908dbfc69592ae1d524e6a20e8bf26b03213644285c2f0L42-R52) [[15]](diffhunk://#diff-81d79bda66a1e914f7d836dc42d8534eb9cf85a3d9365ce4c8acad0af7e6d33cL2-R6) [[16]](diffhunk://#diff-81d79bda66a1e914f7d836dc42d8534eb9cf85a3d9365ce4c8acad0af7e6d33cL99-R108) [[17]](diffhunk://#diff-81d79bda66a1e914f7d836dc42d8534eb9cf85a3d9365ce4c8acad0af7e6d33cL154-R160) [[18]](diffhunk://#diff-a19d8e70c8b07b58c8d11a0d6e1fed06b78a4f61ea06b8f73564627ede3d1518L8-R12) [[19]](diffhunk://#diff-a19d8e70c8b07b58c8d11a0d6e1fed06b78a4f61ea06b8f73564627ede3d1518L68-R77) [[20]](diffhunk://#diff-a19d8e70c8b07b58c8d11a0d6e1fed06b78a4f61ea06b8f73564627ede3d1518L157-R163)

**Frontend: Improved Metadata and Accessibility**

* Enhanced dynamic notebook page metadata: now fetches notebook name to set page title and OpenGraph/Twitter metadata for better SEO and sharing. ([apps/client/app/notebooks/[id]/page.tsxL1-R75](diffhunk://#diff-aee2fb7da3b25ad5d043cbd19b650d18403baaab25d9f15c7bd6b108f6f2b9eaL1-R75), [apps/client/app/layout.tsxR7-R24](diffhunk://#diff-b3bf84a6f6442e17e0f9e3079eca7459eb188f5a2fd70b373226941ef8e3eb4bR7-R24))
* Updated the sidebar "New Notebook" button for improved accessibility and responsive layout, including `aria-label` and `title` attributes.

**Frontend: UI Enhancements**

* Added new controls for clearing outputs and restarting the kernel in the notebook view, using new state and reducer hooks to manage UI state. [[1]](diffhunk://#diff-cffb1f04cf6435d928230f3851a0bca5587c2ed10bb9daaeb1c9666612da3232L3-R10) [[2]](diffhunk://#diff-cffb1f04cf6435d928230f3851a0bca5587c2ed10bb9daaeb1c9666612da3232R22) [[3]](diffhunk://#diff-cffb1f04cf6435d928230f3851a0bca5587c2ed10bb9daaeb1c9666612da3232R80-R85) [[4]](diffhunk://#diff-cffb1f04cf6435d928230f3851a0bca5587c2ed10bb9daaeb1c9666612da3232R109)

**Documentation: React Guidelines**

* Added a new section to `AGENTS.md` with clear guidelines on when to use (and not use) React's `useEffect`, helping developers write more idiomatic and maintainable React code.