### PR TITLE
feat: add notebook import and export

### DIFF
--- a/apps/backend/src/notebooks/file.ts
+++ b/apps/backend/src/notebooks/file.ts
@@ -1,0 +1,130 @@
+import {
+  createCodeCell,
+  createEmptyNotebook,
+  createMarkdownCell,
+  ensureNotebookRuntimeVersion,
+  NotebookEnvSchema,
+  type CodeCell,
+  type MarkdownCell,
+  type Notebook,
+  type NotebookCell,
+  type NotebookEnv,
+  type NotebookFile,
+  type NotebookFileCell,
+  type NotebookFileCodeCell,
+  type NotebookFileNotebook,
+} from "@nodebooks/notebook-schema";
+
+const cloneEnv = (env?: NotebookFileNotebook["env"]): NotebookEnv => {
+  const config = env ?? {};
+  return NotebookEnvSchema.parse({
+    ...config,
+    packages: config.packages ?? {},
+    variables: config.variables ?? {},
+  });
+};
+
+const cloneCells = (cells: NotebookFileCell[]): NotebookCell[] => {
+  return cells.map((cell) => {
+    if (cell.type === "markdown") {
+      return createMarkdownCell({
+        source: cell.source,
+        metadata: cell.metadata ?? {},
+      });
+    }
+    const codeCell = cell as NotebookFileCodeCell;
+    return createCodeCell({
+      language: codeCell.language ?? "ts",
+      source: codeCell.source,
+      metadata: codeCell.metadata ?? {},
+      outputs: codeCell.outputs ?? [],
+    });
+  });
+};
+
+export const createNotebookFromFileDefinition = (
+  file: NotebookFile
+): Notebook => {
+  const env = cloneEnv(file.notebook.env);
+  const cells = cloneCells(file.notebook.cells ?? []);
+  const name =
+    file.notebook.name ?? file.title ?? file.description ?? "Imported Notebook";
+  return ensureNotebookRuntimeVersion(
+    createEmptyNotebook({
+      name,
+      env,
+      cells,
+    })
+  );
+};
+
+const isEmptyRecord = (value: Record<string, unknown> | undefined | null) => {
+  if (!value) {
+    return true;
+  }
+  return Object.keys(value).length === 0;
+};
+
+const serializeEnv = (env: NotebookEnv): NotebookFileNotebook["env"] => {
+  const result: NotebookFileNotebook["env"] = {
+    runtime: env.runtime,
+    version: env.version,
+  };
+  if (!isEmptyRecord(env.packages)) {
+    result.packages = env.packages;
+  }
+  if (!isEmptyRecord(env.variables)) {
+    result.variables = env.variables;
+  }
+  return result;
+};
+
+const serializeMarkdownCell = (cell: MarkdownCell): NotebookFileCell => {
+  const result: NotebookFileCell = {
+    type: "markdown",
+    source: cell.source,
+  };
+  if (!isEmptyRecord(cell.metadata)) {
+    result.metadata = cell.metadata;
+  }
+  return result;
+};
+
+const serializeCodeCell = (cell: CodeCell): NotebookFileCell => {
+  const result: NotebookFileCell = {
+    type: "code",
+    language: cell.language,
+    source: cell.source,
+  };
+  if (!isEmptyRecord(cell.metadata)) {
+    result.metadata = cell.metadata;
+  }
+  if (cell.outputs && cell.outputs.length > 0) {
+    result.outputs = cell.outputs;
+  }
+  return result;
+};
+
+const serializeCells = (cells: NotebookCell[]): NotebookFileCell[] => {
+  return cells.map((cell) => {
+    if (cell.type === "markdown") {
+      return serializeMarkdownCell(cell);
+    }
+    return serializeCodeCell(cell as CodeCell);
+  });
+};
+
+export const serializeNotebookToFileDefinition = (
+  notebook: Notebook
+): NotebookFile => {
+  const env = serializeEnv(notebook.env);
+  const cells = serializeCells(notebook.cells);
+  return {
+    title: notebook.name,
+    notebook: {
+      name: notebook.name,
+      env,
+      cells,
+    },
+  };
+};

--- a/apps/backend/src/routes/notebooks.ts
+++ b/apps/backend/src/routes/notebooks.ts
@@ -151,9 +151,7 @@ export const registerNotebookRoutes = (
 
     let parsedFile;
     try {
-      parsedFile = NotebookFileSchema.parse(
-        YAML.parse(body.data.contents)
-      );
+      parsedFile = NotebookFileSchema.parse(YAML.parse(body.data.contents));
     } catch (error) {
       reply.code(400);
       const message =
@@ -181,18 +179,16 @@ export const registerNotebookRoutes = (
       formatNotebook(notebook)
     );
     const yamlText = YAML.stringify(serialized);
-    const baseName = notebook.name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 64) || "notebook";
+    const baseName =
+      notebook.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 64) || "notebook";
     const filename = `${baseName}.nbdm`;
 
     reply.header("Content-Type", "application/x-yaml; charset=utf-8");
-    reply.header(
-      "Content-Disposition",
-      `attachment; filename="${filename}"`
-    );
+    reply.header("Content-Disposition", `attachment; filename="${filename}"`);
     return yamlText;
   });
 };

--- a/apps/backend/src/templates/index.ts
+++ b/apps/backend/src/templates/index.ts
@@ -5,6 +5,7 @@ import YAML from "yaml";
 import {
   NotebookFileSchema,
   NotebookTemplateSummarySchema,
+  type Notebook,
   type NotebookFile,
   type NotebookTemplateSummary,
 } from "@nodebooks/notebook-schema";

--- a/apps/client/app/notebooks/page.tsx
+++ b/apps/client/app/notebooks/page.tsx
@@ -3,7 +3,6 @@
 import {
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type ChangeEvent,
@@ -11,14 +10,7 @@ import {
 import AppShell from "../../components/app-shell";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import {
-  Play,
-  Trash2,
-  Plus,
-  Download,
-  Upload,
-  Loader2,
-} from "lucide-react";
+import { Play, Trash2, Plus, Download, Upload, Loader2 } from "lucide-react";
 import ConfirmDialog from "@/components/ui/confirm";
 import type { Notebook } from "@nodebooks/notebook-schema";
 import { useRouter } from "next/navigation";
@@ -82,7 +74,7 @@ export default function NotebooksPage() {
 
   const handleImportFile = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
-      const [file] = event.target.files ?? [];
+      const file = event.target.files?.[0];
       if (!file) {
         return;
       }
@@ -169,85 +161,6 @@ export default function NotebooksPage() {
     [slugify]
   );
 
-  const content = useMemo(() => {
-    if (loading) {
-      return <LoadingOverlay label="Loading notebooks…" />;
-    }
-    if (list.length === 0) {
-      return (
-        <Card className="max-w-xl">
-          <CardContent className="flex items-center justify-between gap-4">
-            <p className="text-sm text-muted-foreground">No notebooks yet.</p>
-            <Button
-              size="sm"
-              variant="default"
-              className="gap-2"
-              onClick={handleCreate}
-            >
-              <Plus className="h-4 w-4" /> New notebook
-            </Button>
-          </CardContent>
-        </Card>
-      );
-    }
-    return (
-      <div className="mt-8 space-y-3">
-        {list.map((n) => (
-          <Card
-            key={n.id}
-            className="flex flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between"
-          >
-            <div className="min-w-0">
-              <h3 className="truncate text-lg font-semibold text-card-foreground">
-                {n.name}
-              </h3>
-              <p className="text-sm text-muted-foreground">
-                Updated {new Date(n.updatedAt).toLocaleString()}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="default"
-                size="sm"
-                className="gap-2"
-                onClick={() => handleOpen(n.id)}
-              >
-                <Play className="h-4 w-4" />
-                Open
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => handleExport(n)}
-                disabled={exportingId === n.id}
-                aria-label={`Export ${n.name}`}
-                title="Export notebook"
-              >
-                {exportingId === n.id ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Download className="h-4 w-4" />
-                )}
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-rose-600 hover:text-rose-700"
-                onClick={() => {
-                  setPendingDeleteId(n.id);
-                  setConfirmOpen(true);
-                }}
-                aria-label={`Delete ${n.name}`}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </div>
-          </Card>
-        ))}
-      </div>
-    );
-  }, [loading, list, handleCreate, handleOpen, handleExport, exportingId]);
-
   return (
     <AppShell
       title="Notebooks"
@@ -285,7 +198,78 @@ export default function NotebooksPage() {
       {actionError ? (
         <p className="mt-4 text-sm text-rose-600">{actionError}</p>
       ) : null}
-      {content}
+      {loading ? (
+        <LoadingOverlay label="Loading notebooks…" />
+      ) : list.length === 0 ? (
+        <Card className="max-w-xl">
+          <CardContent className="flex items-center justify-between gap-4">
+            <p className="text-sm text-muted-foreground">No notebooks yet.</p>
+            <Button
+              size="sm"
+              variant="default"
+              className="gap-2"
+              onClick={handleCreate}
+            >
+              <Plus className="h-4 w-4" /> New notebook
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="mt-8 space-y-3">
+          {list.map((n) => (
+            <Card
+              key={n.id}
+              className="flex flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0">
+                <h3 className="truncate text-lg font-semibold text-card-foreground">
+                  {n.name}
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Updated {new Date(n.updatedAt).toLocaleString()}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="gap-2"
+                  onClick={() => handleOpen(n.id)}
+                >
+                  <Play className="h-4 w-4" />
+                  Open
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleExport(n)}
+                  disabled={exportingId === n.id}
+                  aria-label={`Export ${n.name}`}
+                  title="Export notebook"
+                >
+                  {exportingId === n.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Download className="h-4 w-4" />
+                  )}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-rose-600 hover:text-rose-700"
+                  onClick={() => {
+                    setPendingDeleteId(n.id);
+                    setConfirmOpen(true);
+                  }}
+                  aria-label={`Delete ${n.name}`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
       <ConfirmDialog
         open={confirmOpen}
         title="Delete notebook?"

--- a/apps/client/components/notebook-view.tsx
+++ b/apps/client/components/notebook-view.tsx
@@ -1090,7 +1090,9 @@ const NotebookView = ({ initialNotebookId }: NotebookViewProps) => {
     setExporting(true);
     setActionError(null);
     try {
-      const res = await fetch(`${API_BASE_URL}/notebooks/${notebook.id}/export`);
+      const res = await fetch(
+        `${API_BASE_URL}/notebooks/${notebook.id}/export`
+      );
       if (!res.ok) {
         const payload = await res.json().catch(() => null);
         const message =
@@ -1461,6 +1463,7 @@ const NotebookView = ({ initialNotebookId }: NotebookViewProps) => {
     notebook,
     socketReady,
     error,
+    actionError,
     runningCellId,
     runQueue,
     handleCellChange,
@@ -1596,20 +1599,7 @@ const NotebookView = ({ initialNotebookId }: NotebookViewProps) => {
           >
             <PlayCircle className="h-4 w-4" />
           </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleExportNotebook}
-            aria-label="Export notebook"
-            title="Export notebook"
-            disabled={exporting}
-          >
-            {exporting ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Download className="h-4 w-4" />
-            )}
-          </Button>
+
           <Button
             variant="ghost"
             size="icon"
@@ -1653,6 +1643,20 @@ const NotebookView = ({ initialNotebookId }: NotebookViewProps) => {
               <Check className="h-4 w-4 text-emerald-500" />
             ) : (
               <Share2 className="h-4 w-4" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleExportNotebook}
+            aria-label="Export notebook"
+            title="Export notebook"
+            disabled={exporting}
+          >
+            {exporting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="h-4 w-4" />
             )}
           </Button>
           <Button

--- a/apps/client/components/notebook/outline-panel.tsx
+++ b/apps/client/components/notebook/outline-panel.tsx
@@ -13,11 +13,6 @@ interface OutlinePanelProps {
 const OutlinePanel = ({ items, onSelect, activeCellId }: OutlinePanelProps) => {
   return (
     <div className="flex h-full flex-col gap-4">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-          Outline
-        </p>
-      </div>
       {items.length === 0 ? (
         <p className="text-xs text-muted-foreground">
           Add headings to your Markdown cells to build an outline.

--- a/apps/client/components/notebook/setup-panel.tsx
+++ b/apps/client/components/notebook/setup-panel.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { setDiagnosticPolicy } from "@/components/notebook/monaco-setup";
+import { Separator } from "@/components/ui/separator";
 
 interface SetupPanelProps {
   env: Notebook["env"];
@@ -68,42 +69,7 @@ const SetupPanel = ({
   );
 
   return (
-    <div className="flex h-full flex-col gap-4">
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-          Runtime
-        </p>
-        <div className="mt-1">
-          <Badge variant="secondary" className="uppercase tracking-[0.2em]">
-            {env.runtime.toUpperCase()} {env.version}
-          </Badge>
-        </div>
-        <div className="mt-3">
-          <label className="block text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-            Typing Mode
-          </label>
-          <div className="mt-1">
-            <select
-              className="w-full rounded-md border border-input bg-background px-2 py-1 text-[13px] text-foreground focus:outline-none"
-              value={typingMode}
-              onChange={(e) => {
-                const val = e.target.value as "ignore" | "off" | "full";
-                setTypingMode(val);
-                if (val === "off") setDiagnosticPolicy({ mode: "off" });
-                else if (val === "full") setDiagnosticPolicy({ mode: "full" });
-                else setDiagnosticPolicy({ mode: "ignore-list" });
-              }}
-            >
-              <option value="ignore">Ignore noisy errors</option>
-              <option value="off">No diagnostics</option>
-              <option value="full">Full TypeScript checks</option>
-            </select>
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Controls Monaco diagnostics in the editor.
-            </p>
-          </div>
-        </div>
-      </div>
+    <div className="flex h-full flex-col gap-2">
       <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
         Dependencies
       </p>
@@ -157,8 +123,9 @@ const SetupPanel = ({
           </ul>
         )}
       </div>
-      <div>
-        <p className="mt-2 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+      <Separator className="my-2" />
+      <div className="mt-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
           Environment Variables
         </p>
         <div className="mt-2 flex items-center justify-between">
@@ -201,6 +168,32 @@ const SetupPanel = ({
               ))}
             </ul>
           )}
+        </div>
+      </div>
+      <Separator className="my-2" />
+      <div className="mt-3">
+        <label className="block text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+          Typing Mode
+        </label>
+        <div className="mt-1">
+          <select
+            className="w-full rounded-md border border-input bg-background px-2 py-1 text-[13px] text-foreground focus:outline-none"
+            value={typingMode}
+            onChange={(e) => {
+              const val = e.target.value as "ignore" | "off" | "full";
+              setTypingMode(val);
+              if (val === "off") setDiagnosticPolicy({ mode: "off" });
+              else if (val === "full") setDiagnosticPolicy({ mode: "full" });
+              else setDiagnosticPolicy({ mode: "ignore-list" });
+            }}
+          >
+            <option value="ignore">Ignore noisy errors</option>
+            <option value="off">No diagnostics</option>
+            <option value="full">Full TypeScript checks</option>
+          </select>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Controls Monaco diagnostics in the editor.
+          </p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- share a reusable notebook file schema so .nbdm bundles can be parsed and generated
- implement backend helpers plus import/export endpoints that read and emit YAML notebooks
- expose import and export controls on the notebooks list and notebook editor UIs

## Testing
- pnpm --filter @nodebooks/notebook-schema test
- pnpm --filter @nodebooks/server lint

------
https://chatgpt.com/codex/tasks/task_e_68db197621d8832d8ea0b01cc9a68718