### PR TITLE
feat: support markdown image attachments

### DIFF
--- a/apps/backend/src/routes/attachments.ts
+++ b/apps/backend/src/routes/attachments.ts
@@ -1,0 +1,344 @@
+import { Buffer } from "node:buffer";
+import type { FastifyInstance } from "fastify";
+import { customAlphabet } from "nanoid";
+import { z } from "zod";
+import type { NotebookAttachment, NotebookStore } from "../types.js";
+
+const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024; // 10 MiB ceiling per file
+const MAX_CHUNK_SIZE_BYTES = 512 * 1024; // 512 KiB per chunk to stay below Fastify bodyLimit
+const UPLOAD_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+const AttachmentUploadInitSchema = z.object({
+  filename: z.string().min(1),
+  mimeType: z.string().min(1).default("application/octet-stream"),
+  size: z.number().int().nonnegative().optional(),
+});
+
+const AttachmentChunkSchema = z.object({
+  chunk: z.string().min(1),
+  index: z.number().int().nonnegative(),
+  isLast: z.boolean().optional().default(false),
+});
+
+const AttachmentDeleteParamsSchema = z.object({
+  id: z.string(),
+  attachmentId: z.string(),
+});
+
+const AttachmentParamsSchema = z.object({ id: z.string() });
+
+type PendingUpload = {
+  id: string;
+  notebookId: string;
+  filename: string;
+  mimeType: string;
+  expectedSize?: number;
+  createdAt: number;
+  nextIndex: number;
+  totalBytes: number;
+  chunks: Buffer[];
+};
+
+const nanoid = customAlphabet("1234567890abcdefghijklmnopqrstuvwxyz", 16);
+
+const encodeUrlComponent = (value: string) => encodeURIComponent(value);
+
+const buildAttachmentContentUrl = (notebookId: string, attachmentId: string) =>
+  `/api/notebooks/${encodeUrlComponent(notebookId)}/attachments/${encodeUrlComponent(
+    attachmentId
+  )}/content`;
+
+const cleanupExpiredUploads = (
+  uploads: Map<string, PendingUpload>,
+  now = Date.now()
+) => {
+  for (const [id, pending] of uploads) {
+    if (now - pending.createdAt > UPLOAD_TTL_MS) {
+      uploads.delete(id);
+    }
+  }
+};
+
+const decodeChunk = (chunk: string): Buffer => {
+  try {
+    const buffer = Buffer.from(chunk, "base64");
+    if (buffer.byteLength === 0) {
+      throw new Error("Empty chunk");
+    }
+    return buffer;
+  } catch (error) {
+    throw new Error(
+      error instanceof Error ? error.message : "Invalid base64 chunk"
+    );
+  }
+};
+
+const persistAttachment = async (
+  store: NotebookStore,
+  upload: PendingUpload
+) => {
+  const content = Buffer.concat(upload.chunks, upload.totalBytes);
+  const attachment = await store.saveAttachment(upload.notebookId, {
+    filename: upload.filename,
+    mimeType: upload.mimeType,
+    content,
+  });
+  return attachment;
+};
+
+const summarize = (attachment: NotebookAttachment) => ({
+  id: attachment.id,
+  notebookId: attachment.notebookId,
+  filename: attachment.filename,
+  mimeType: attachment.mimeType,
+  size: attachment.size,
+  createdAt: attachment.createdAt,
+  updatedAt: attachment.updatedAt,
+});
+
+export const registerAttachmentRoutes = (
+  app: FastifyInstance,
+  store: NotebookStore
+) => {
+  const uploads = new Map<string, PendingUpload>();
+
+  app.get("/notebooks/:id/attachments", async (request, reply) => {
+    const params = AttachmentParamsSchema.safeParse(request.params);
+    if (!params.success) {
+      reply.code(400);
+      return { error: "Invalid notebook id" };
+    }
+
+    const notebook = await store.get(params.data.id);
+    if (!notebook) {
+      reply.code(404);
+      return { error: "Notebook not found" };
+    }
+
+    const attachments = await store.listAttachments(notebook.id);
+    return { data: attachments.map(summarize) };
+  });
+
+  app.post("/notebooks/:id/attachments/uploads", async (request, reply) => {
+    const params = AttachmentParamsSchema.safeParse(request.params);
+    if (!params.success) {
+      reply.code(400);
+      return { error: "Invalid notebook id" };
+    }
+
+    const body = AttachmentUploadInitSchema.safeParse(request.body ?? {});
+    if (!body.success) {
+      reply.code(400);
+      return { error: "Invalid attachment metadata" };
+    }
+
+    const notebook = await store.get(params.data.id);
+    if (!notebook) {
+      reply.code(404);
+      return { error: "Notebook not found" };
+    }
+
+    if (typeof body.data.size === "number") {
+      if (body.data.size === 0) {
+        reply.code(400);
+        return { error: "Attachment size must be greater than zero" };
+      }
+      if (body.data.size > MAX_ATTACHMENT_SIZE_BYTES) {
+        reply.code(413);
+        return { error: "Attachment exceeds maximum allowed size" };
+      }
+    }
+
+    cleanupExpiredUploads(uploads);
+
+    const uploadId = nanoid();
+    uploads.set(uploadId, {
+      id: uploadId,
+      notebookId: notebook.id,
+      filename: body.data.filename,
+      mimeType: body.data.mimeType,
+      expectedSize: body.data.size,
+      createdAt: Date.now(),
+      nextIndex: 0,
+      totalBytes: 0,
+      chunks: [],
+    });
+
+    reply.code(201);
+    return {
+      data: {
+        uploadId,
+        maxChunkBytes: MAX_CHUNK_SIZE_BYTES,
+        maxAttachmentBytes: MAX_ATTACHMENT_SIZE_BYTES,
+      },
+    };
+  });
+
+  app.post(
+    "/notebooks/:id/attachments/uploads/:uploadId/chunk",
+    async (request, reply) => {
+      const params = z
+        .object({ id: z.string(), uploadId: z.string() })
+        .safeParse(request.params);
+      if (!params.success) {
+        reply.code(400);
+        return { error: "Invalid upload parameters" };
+      }
+
+      const body = AttachmentChunkSchema.safeParse(request.body ?? {});
+      if (!body.success) {
+        reply.code(400);
+        return { error: "Invalid attachment chunk" };
+      }
+
+      const upload = uploads.get(params.data.uploadId);
+      if (!upload || upload.notebookId !== params.data.id) {
+        reply.code(404);
+        return { error: "Upload session not found" };
+      }
+
+      if (body.data.index !== upload.nextIndex) {
+        reply.code(409);
+        return { error: "Unexpected chunk index" };
+      }
+
+      let decoded: Buffer;
+      try {
+        decoded = decodeChunk(body.data.chunk);
+      } catch (error) {
+        reply.code(400);
+        return {
+          error: error instanceof Error ? error.message : "Invalid chunk",
+        };
+      }
+
+      if (decoded.byteLength > MAX_CHUNK_SIZE_BYTES) {
+        reply.code(413);
+        return { error: "Chunk exceeds maximum allowed size" };
+      }
+
+      const nextTotal = upload.totalBytes + decoded.byteLength;
+      if (nextTotal > MAX_ATTACHMENT_SIZE_BYTES) {
+        reply.code(413);
+        return { error: "Attachment exceeds maximum allowed size" };
+      }
+
+      upload.chunks.push(decoded);
+      upload.totalBytes = nextTotal;
+      upload.nextIndex += 1;
+
+      const isLast = body.data.isLast ?? false;
+      if (!isLast) {
+        return {
+          data: {
+            receivedBytes: upload.totalBytes,
+            nextIndex: upload.nextIndex,
+          },
+        };
+      }
+
+      if (upload.expectedSize && upload.expectedSize !== upload.totalBytes) {
+        uploads.delete(upload.id);
+        reply.code(400);
+        return { error: "Attachment size does not match declared size" };
+      }
+
+      uploads.delete(upload.id);
+
+      try {
+        const attachment = await persistAttachment(store, upload);
+        return {
+          data: {
+            attachment: summarize(attachment),
+            url: buildAttachmentContentUrl(
+              attachment.notebookId,
+              attachment.id
+            ),
+          },
+        };
+      } catch (error) {
+        reply.code(500);
+        return {
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to persist attachment",
+        };
+      }
+    }
+  );
+
+  app.get(
+    "/notebooks/:id/attachments/:attachmentId",
+    async (request, reply) => {
+      const params = AttachmentDeleteParamsSchema.safeParse(request.params);
+      if (!params.success) {
+        reply.code(400);
+        return { error: "Invalid attachment parameters" };
+      }
+
+      const attachment = await store.getAttachment(
+        params.data.id,
+        params.data.attachmentId
+      );
+      if (!attachment) {
+        reply.code(404);
+        return { error: "Attachment not found" };
+      }
+
+      return { data: summarize(attachment) };
+    }
+  );
+
+  app.get(
+    "/notebooks/:id/attachments/:attachmentId/content",
+    async (request, reply) => {
+      const params = AttachmentDeleteParamsSchema.safeParse(request.params);
+      if (!params.success) {
+        reply.code(400);
+        return { error: "Invalid attachment parameters" };
+      }
+
+      const attachment = await store.getAttachment(
+        params.data.id,
+        params.data.attachmentId
+      );
+      if (!attachment) {
+        reply.code(404);
+        return { error: "Attachment not found" };
+      }
+
+      reply.header("Content-Type", attachment.mimeType);
+      reply.header("Content-Length", String(attachment.size));
+      reply.header(
+        "Content-Disposition",
+        `inline; filename="${attachment.filename.replace(/"/g, '\\"')}"`
+      );
+
+      return reply.send(Buffer.from(attachment.content));
+    }
+  );
+
+  app.delete(
+    "/notebooks/:id/attachments/:attachmentId",
+    async (request, reply) => {
+      const params = AttachmentDeleteParamsSchema.safeParse(request.params);
+      if (!params.success) {
+        reply.code(400);
+        return { error: "Invalid attachment parameters" };
+      }
+
+      const removed = await store.removeAttachment(
+        params.data.id,
+        params.data.attachmentId
+      );
+      if (!removed) {
+        reply.code(404);
+        return { error: "Attachment not found" };
+      }
+
+      reply.code(204);
+      return null;
+    }
+  );
+};

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -25,6 +25,7 @@ import { registerDependencyRoutes } from "./routes/dependencies.js";
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerTemplateRoutes } from "./routes/templates.js";
 import { registerTypesRoutes } from "./routes/types.js";
+import { registerAttachmentRoutes } from "./routes/attachments.js";
 import { createKernelUpgradeHandler } from "./kernel/router.js";
 import {
   PASSWORD_COOKIE_NAME,
@@ -267,6 +268,7 @@ export const createServer = async ({
         cookieOptions:
           cookieOptions as FastifyCookieNamespace.CookieSerializeOptions,
       });
+      registerAttachmentRoutes(api, store);
       registerNotebookRoutes(api, store);
       registerDependencyRoutes(api, store);
       registerSessionRoutes(api, sessions);

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -1,5 +1,19 @@
 import type { Notebook } from "@nodebooks/notebook-schema";
 
+export interface NotebookAttachment {
+  id: string;
+  notebookId: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NotebookAttachmentContent extends NotebookAttachment {
+  content: Uint8Array;
+}
+
 export interface NotebookSession {
   id: string;
   notebookId: string;
@@ -18,6 +32,20 @@ export interface NotebookStore {
   get(id: string): Promise<Notebook | undefined>;
   save(notebook: Notebook): Promise<Notebook>;
   remove(id: string): Promise<Notebook | undefined>;
+  listAttachments(notebookId: string): Promise<NotebookAttachment[]>;
+  getAttachment(
+    notebookId: string,
+    attachmentId: string
+  ): Promise<NotebookAttachmentContent | undefined>;
+  saveAttachment(
+    notebookId: string,
+    input: {
+      filename: string;
+      mimeType: string;
+      content: Uint8Array;
+    }
+  ): Promise<NotebookAttachment>;
+  removeAttachment(notebookId: string, attachmentId: string): Promise<boolean>;
 }
 
 export interface SettingsStore {

--- a/apps/backend/tests/server.test.ts
+++ b/apps/backend/tests/server.test.ts
@@ -110,6 +110,9 @@ vi.mock("../src/routes/notebooks.js", () => ({
 vi.mock("../src/routes/dependencies.js", () => ({
   registerDependencyRoutes: () => {},
 }));
+vi.mock("../src/routes/attachments.js", () => ({
+  registerAttachmentRoutes: () => {},
+}));
 vi.mock("../src/routes/sessions.js", () => ({
   registerSessionRoutes: () => {},
 }));

--- a/apps/client/components/notebook/attachment-utils.ts
+++ b/apps/client/components/notebook/attachment-utils.ts
@@ -1,0 +1,293 @@
+import type { DragEventHandler } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { clientConfig } from "@nodebooks/config/client";
+
+const apiBaseRaw = clientConfig().apiBaseUrl ?? "/api";
+const apiBase =
+  apiBaseRaw.length > 1 && apiBaseRaw.endsWith("/")
+    ? apiBaseRaw.replace(/\/+$/, "")
+    : apiBaseRaw;
+
+const MAX_CHUNK_FALLBACK = 512 * 1024;
+
+const encodeBytesToBase64 = (bytes: Uint8Array) => {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunk) {
+    const slice = bytes.subarray(offset, offset + chunk);
+    binary += String.fromCharCode(...slice);
+  }
+  return btoa(binary);
+};
+
+const attachmentsBasePath = (notebookId: string) =>
+  `${apiBase}/notebooks/${encodeURIComponent(notebookId)}/attachments`;
+
+const chunkEndpoint = (notebookId: string, uploadId: string) =>
+  `${attachmentsBasePath(notebookId)}/uploads/${encodeURIComponent(uploadId)}/chunk`;
+
+export const buildAttachmentContentUrl = (
+  notebookId: string,
+  attachmentId: string
+) =>
+  `${attachmentsBasePath(notebookId)}/${encodeURIComponent(
+    attachmentId
+  )}/content`;
+
+export interface AttachmentMetadata {
+  id: string;
+  notebookId: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AttachmentUploadResult {
+  attachment: AttachmentMetadata;
+  url: string;
+}
+
+export interface AttachmentUploadStatus {
+  total: number;
+  current: number;
+}
+
+interface UploadInitResponse {
+  data?: {
+    uploadId?: string;
+    maxChunkBytes?: number;
+  };
+  error?: string;
+}
+
+interface UploadChunkResponse {
+  data?: AttachmentUploadResult;
+  error?: string;
+}
+
+const readErrorMessage = async (response: Response) => {
+  try {
+    const payload = await response.clone().json();
+    if (payload?.error) {
+      return String(payload.error);
+    }
+  } catch {
+    const text = await response.clone().text();
+    if (text) return text;
+  }
+  return `Request failed with status ${response.status}`;
+};
+
+export const useAttachmentUploader = ({
+  notebookId,
+  onUploaded,
+}: {
+  notebookId: string;
+  onUploaded?: (attachment: AttachmentMetadata, url: string) => void;
+}) => {
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadStatus, setUploadStatus] =
+    useState<AttachmentUploadStatus | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const baseUrl = useMemo(() => attachmentsBasePath(notebookId), [notebookId]);
+
+  const uploadSingle = useCallback(
+    async (file: File): Promise<AttachmentUploadResult> => {
+      const initResponse = await fetch(`${baseUrl}/uploads`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          filename: file.name,
+          mimeType: file.type || "application/octet-stream",
+          size: file.size,
+        }),
+      });
+
+      if (!initResponse.ok) {
+        const message = await readErrorMessage(initResponse);
+        throw new Error(message);
+      }
+
+      const initPayload = (await initResponse.json()) as UploadInitResponse;
+      const uploadId = initPayload?.data?.uploadId;
+      if (!uploadId) {
+        throw new Error("Upload session not initialised");
+      }
+
+      const chunkSizeRaw = initPayload?.data?.maxChunkBytes;
+      const chunkSize =
+        typeof chunkSizeRaw === "number" && chunkSizeRaw > 0
+          ? chunkSizeRaw
+          : MAX_CHUNK_FALLBACK;
+
+      const endpoint = chunkEndpoint(notebookId, uploadId);
+      let offset = 0;
+      let index = 0;
+      let finalPayload: AttachmentUploadResult | undefined;
+
+      while (offset < file.size) {
+        const end = Math.min(offset + chunkSize, file.size);
+        const buffer = await file.slice(offset, end).arrayBuffer();
+        const chunkBase64 = encodeBytesToBase64(new Uint8Array(buffer));
+        const isLast = end >= file.size;
+
+        const chunkResponse = await fetch(endpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ chunk: chunkBase64, index, isLast }),
+        });
+
+        if (!chunkResponse.ok) {
+          const message = await readErrorMessage(chunkResponse);
+          throw new Error(message);
+        }
+
+        if (isLast) {
+          const payload = (await chunkResponse.json()) as
+            | UploadChunkResponse
+            | undefined;
+          if (!payload?.data) {
+            throw new Error(
+              payload?.error ?? "Attachment upload did not finish"
+            );
+          }
+          finalPayload = payload.data;
+        }
+
+        offset = end;
+        index += 1;
+      }
+
+      if (!finalPayload) {
+        throw new Error("Attachment upload did not return metadata");
+      }
+
+      return finalPayload;
+    },
+    [baseUrl, notebookId]
+  );
+
+  const uploadFiles = useCallback(
+    async (files: File[]) => {
+      const valid = files.filter((file) => file && file.size > 0);
+      if (valid.length === 0) {
+        return [] as AttachmentUploadResult[];
+      }
+
+      setUploadError(null);
+      setIsUploading(true);
+      setUploadStatus({ total: valid.length, current: 0 });
+
+      const results: AttachmentUploadResult[] = [];
+      try {
+        for (let i = 0; i < valid.length; i += 1) {
+          setUploadStatus({ total: valid.length, current: i + 1 });
+          const result = await uploadSingle(valid[i]);
+          results.push(result);
+          onUploaded?.(result.attachment, result.url);
+        }
+        return results;
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to upload attachment";
+        setUploadError(message);
+        return results;
+      } finally {
+        setIsUploading(false);
+        setUploadStatus(null);
+      }
+    },
+    [onUploaded, uploadSingle]
+  );
+
+  const resetError = useCallback(() => setUploadError(null), []);
+
+  return {
+    uploadFiles,
+    isUploading,
+    uploadStatus,
+    uploadError,
+    resetError,
+  } as const;
+};
+
+const isFileDrag = (event: React.DragEvent<HTMLElement>) => {
+  const types = Array.from(event.dataTransfer?.types ?? []);
+  return types.includes("Files");
+};
+
+export const useAttachmentDropzone = ({
+  disabled,
+  onFiles,
+}: {
+  disabled?: boolean;
+  onFiles: (files: File[]) => void | Promise<void>;
+}) => {
+  const dragDepthRef = useRef(0);
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+
+  const resetDragState = useCallback(() => {
+    dragDepthRef.current = 0;
+    setIsDraggingOver(false);
+  }, []);
+
+  const handleDragEnter = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      if (disabled || !isFileDrag(event)) return;
+      event.preventDefault();
+      dragDepthRef.current += 1;
+      setIsDraggingOver(true);
+    },
+    [disabled]
+  );
+
+  const handleDragOver = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      if (disabled || !isFileDrag(event)) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "copy";
+    },
+    [disabled]
+  );
+
+  const handleDragLeave = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      if (disabled || !isFileDrag(event)) return;
+      event.preventDefault();
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+      if (dragDepthRef.current === 0) {
+        setIsDraggingOver(false);
+      }
+    },
+    [disabled]
+  );
+
+  const handleDrop = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      if (disabled || !isFileDrag(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const files = Array.from(event.dataTransfer?.files ?? []).filter(
+        (file) => file && file.size > 0
+      );
+      resetDragState();
+      if (files.length === 0) return;
+      void onFiles(files);
+    },
+    [disabled, onFiles, resetDragState]
+  );
+
+  return {
+    isDraggingOver,
+    handleDragEnter,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    resetDragState,
+  } as const;
+};

--- a/apps/client/components/notebook/attachments-panel.tsx
+++ b/apps/client/components/notebook/attachments-panel.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  useAttachmentUploader,
+  useAttachmentDropzone,
+  buildAttachmentContentUrl,
+  type AttachmentMetadata,
+} from "@/components/notebook/attachment-utils";
+import MediaDialog from "@/components/ui/media-dialog";
+import {
+  FileIcon,
+  ImageIcon,
+  Link as LinkIcon,
+  Trash2,
+  Copy,
+} from "lucide-react";
+
+export interface AttachmentsPanelProps {
+  notebookId: string;
+  attachments: AttachmentMetadata[];
+  loading?: boolean;
+  error?: string | null;
+  onDelete: (id: string) => Promise<void> | void;
+  onAttachmentUploaded: (attachment: AttachmentMetadata, url: string) => void;
+}
+
+const formatBytes = (value: number) => {
+  if (!Number.isFinite(value) || value < 1024) {
+    return `${value} B`;
+  }
+  const units = ["KB", "MB", "GB", "TB"];
+  let size = value;
+  let unitIndex = -1;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  return `${size.toFixed(size >= 10 ? 0 : 1)} ${units[unitIndex]}`;
+};
+
+const formatDateTime = (value: string) => {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+};
+
+const isImage = (mimeType: string) => mimeType.startsWith("image/");
+
+const AttachmentPreview = ({
+  url,
+  mimeType,
+  alt,
+  onClick,
+}: {
+  url: string;
+  mimeType: string;
+  alt: string;
+  onClick?: () => void;
+}) => {
+  const [broken, setBroken] = useState(false);
+  const showImage = isImage(mimeType) && !broken;
+  const clickable = typeof onClick === "function" && showImage;
+
+  const Wrapper = clickable ? "button" : "div";
+
+  return (
+    <Wrapper
+      type={clickable ? "button" : undefined}
+      onClick={clickable ? onClick : undefined}
+      className={cn(
+        "relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-md bg-muted ring-1 ring-border/80",
+        clickable &&
+          "cursor-zoom-in focus:outline-none focus:ring-2 focus:ring-primary/60"
+      )}
+      aria-label={clickable ? "Preview attachment" : undefined}
+    >
+      {showImage ? (
+        <Image
+          src={url}
+          alt={alt}
+          fill
+          sizes="48px"
+          style={{ objectFit: "cover" }}
+          loading="lazy"
+          unoptimized
+          onError={() => setBroken(true)}
+        />
+      ) : (
+        <FileIcon className="h-6 w-6 text-muted-foreground" />
+      )}
+    </Wrapper>
+  );
+};
+
+const formatDisplayName = (filename: string, maxLength = 28) => {
+  if (filename.length <= maxLength) {
+    return filename;
+  }
+  const dot = filename.lastIndexOf(".");
+  const ext = dot > 0 ? filename.slice(dot) : "";
+  const base = dot > 0 ? filename.slice(0, dot) : filename;
+  const available = maxLength - ext.length - 1;
+  if (available <= 0) {
+    return `${filename.slice(0, maxLength - 1)}…`;
+  }
+  const prefixLength = Math.ceil(available / 2);
+  const suffixLength = Math.floor(available / 2);
+  const prefix = base.slice(0, prefixLength);
+  const suffix = base.slice(base.length - suffixLength);
+  return `${prefix}…${suffix}${ext}`;
+};
+
+const AttachmentsPanel = ({
+  notebookId,
+  attachments,
+  loading = false,
+  error = null,
+  onDelete,
+  onAttachmentUploaded,
+}: AttachmentsPanelProps) => {
+  const [preview, setPreview] = useState<{
+    attachment: AttachmentMetadata;
+    url: string;
+  } | null>(null);
+
+  const handlePreview = useCallback(
+    (attachment: AttachmentMetadata, url: string) => {
+      setPreview({ attachment, url });
+    },
+    []
+  );
+
+  const { uploadFiles, isUploading, uploadStatus, uploadError } =
+    useAttachmentUploader({
+      notebookId,
+      onUploaded: onAttachmentUploaded,
+    });
+
+  const handleUploadFiles = useCallback(
+    async (files: File[]) => {
+      await uploadFiles(files);
+    },
+    [uploadFiles]
+  );
+
+  const {
+    isDraggingOver,
+    handleDragEnter,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+  } = useAttachmentDropzone({
+    disabled: isUploading,
+    onFiles: handleUploadFiles,
+  });
+
+  const sortedAttachments = useMemo(() => {
+    return [...attachments].sort((a, b) => {
+      const aTime = Date.parse(a.createdAt);
+      const bTime = Date.parse(b.createdAt);
+      if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
+        return b.createdAt.localeCompare(a.createdAt);
+      }
+      return bTime - aTime;
+    });
+  }, [attachments]);
+
+  const hasAttachments = sortedAttachments.length > 0;
+
+  return (
+    <>
+      <div
+        className={cn(
+          "relative mb-4 flex flex-col items-center justify-center gap-2 overflow-hidden rounded-md border border-dashed border-border/60 p-4 text-sm text-muted-foreground transition",
+          isDraggingOver && "border-primary text-primary",
+          isUploading && "border-primary/70"
+        )}
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {isDraggingOver ? (
+          <div className="pointer-events-none absolute inset-0 rounded-md border-2 border-dashed border-primary/70 bg-primary/10" />
+        ) : null}
+        {isUploading ? (
+          <span>
+            {uploadStatus
+              ? `Uploading attachment ${uploadStatus.current} of ${uploadStatus.total}…`
+              : "Uploading attachments…"}
+          </span>
+        ) : (
+          <span>Drop files here to upload new attachments</span>
+        )}
+        {uploadError ? (
+          <span className="text-xs text-rose-500">{uploadError}</span>
+        ) : null}
+      </div>
+
+      {error ? <p className="mb-2 text-[11px] text-rose-500">{error}</p> : null}
+
+      {loading ? (
+        <p className="text-[11px] text-muted-foreground">
+          Loading attachments…
+        </p>
+      ) : hasAttachments ? (
+        <ul className="space-y-3">
+          {sortedAttachments.map((attachment) => {
+            const url = buildAttachmentContentUrl(
+              attachment.notebookId,
+              attachment.id
+            );
+            return (
+              <AttachmentRow
+                key={attachment.id}
+                attachment={attachment}
+                url={url}
+                onDelete={onDelete}
+                onPreview={handlePreview}
+              />
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          No attachments uploaded yet.
+        </p>
+      )}
+
+      <MediaDialog
+        open={preview !== null}
+        onOpenChange={(open) => (!open ? setPreview(null) : undefined)}
+        title={preview?.attachment.filename ?? ""}
+        src={preview?.url ?? ""}
+        mimeType={preview?.attachment.mimeType ?? ""}
+        sizeLabel={preview ? formatBytes(preview.attachment.size) : undefined}
+      />
+    </>
+  );
+};
+
+const AttachmentRow = ({
+  attachment,
+  url,
+  onDelete,
+  onPreview,
+}: {
+  attachment: AttachmentMetadata;
+  url: string;
+  onDelete: (id: string) => Promise<void> | void;
+  onPreview: (attachment: AttachmentMetadata, url: string) => void;
+}) => {
+  const [copied, setCopied] = useState(false);
+  const displayName = useMemo(
+    () => formatDisplayName(attachment.filename),
+    [attachment.filename]
+  );
+  const canPreview = isImage(attachment.mimeType);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+      } else if (typeof document !== "undefined") {
+        const textarea = document.createElement("textarea");
+        textarea.value = url;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  }, [url]);
+
+  const handleDelete = useCallback(() => {
+    void onDelete(attachment.id);
+  }, [attachment.id, onDelete]);
+
+  const handlePreview = useCallback(() => {
+    if (!canPreview) return;
+    onPreview(attachment, url);
+  }, [attachment, canPreview, onPreview, url]);
+
+  const previewAlt = `${attachment.filename} preview`;
+
+  return (
+    <li className="flex items-start gap-3 rounded-md border border-border/60 p-3 text-[12px]">
+      <AttachmentPreview
+        url={url}
+        mimeType={attachment.mimeType}
+        alt={previewAlt}
+        onClick={handlePreview}
+      />
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <button
+              type="button"
+              className="block w-full truncate pr-10 text-left font-medium text-foreground hover:underline"
+              onClick={handleCopy}
+              title={attachment.filename}
+            >
+              {displayName}
+            </button>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-foreground"
+              onClick={handleCopy}
+              aria-label="Copy attachment URL"
+            >
+              {copied ? (
+                <LinkIcon className="h-4 w-4" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-rose-600 hover:text-rose-600"
+              onClick={handleDelete}
+              aria-label="Delete attachment"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+          <span>{attachment.mimeType}</span>
+          <span aria-hidden>•</span>
+          <span>{formatBytes(attachment.size)}</span>
+          <span aria-hidden>•</span>
+          <span>{formatDateTime(attachment.createdAt)}</span>
+          {isImage(attachment.mimeType) ? (
+            <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+              <ImageIcon className="h-3.5 w-3.5" />
+              Image
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export default AttachmentsPanel;

--- a/apps/client/components/notebook/cell-card.tsx
+++ b/apps/client/components/notebook/cell-card.tsx
@@ -27,9 +27,12 @@ import {
 import type { NotebookCell } from "@nodebooks/notebook-schema";
 import CodeCellView from "./code-cell-view";
 import MarkdownCellView from "./markdown-cell-view";
+import type { AttachmentMetadata } from "@/components/notebook/attachment-utils";
 
 interface CellCardProps {
   cell: NotebookCell;
+  notebookId: string;
+  onAttachmentUploaded?: (attachment: AttachmentMetadata, url: string) => void;
   onChange: (
     updater: (cell: NotebookCell) => NotebookCell,
     options?: { persist?: boolean; touch?: boolean }
@@ -90,6 +93,8 @@ const AddCellMenu = ({
 
 const CellCard = ({
   cell,
+  notebookId,
+  onAttachmentUploaded,
   onChange,
   onRun,
   onInterrupt,
@@ -325,7 +330,9 @@ const CellCard = ({
           editorKey={editorKey}
           path={editorPath}
           cell={cell}
+          notebookId={notebookId}
           onChange={onChange}
+          onAttachmentUploaded={onAttachmentUploaded}
         />
       )}
 

--- a/apps/client/components/notebook/setup-panel.tsx
+++ b/apps/client/components/notebook/setup-panel.tsx
@@ -67,7 +67,6 @@ const SetupPanel = ({
         .map(([name, value]) => ({ name, value: String(value ?? "") })),
     [env.variables]
   );
-
   return (
     <div className="flex h-full flex-col gap-2">
       <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">

--- a/apps/client/components/ui/media-dialog.tsx
+++ b/apps/client/components/ui/media-dialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+export interface MediaDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  src: string;
+  mimeType: string;
+  sizeLabel?: string;
+}
+
+const MediaDialog = ({
+  open,
+  onOpenChange,
+  title,
+  src,
+  mimeType,
+  sizeLabel,
+}: MediaDialogProps) => {
+  const [broken, setBroken] = useState(false);
+  const isImage = mimeType.startsWith("image/") && !broken;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl gap-4 sm:max-w-6xl">
+        <DialogHeader className="space-y-1">
+          <DialogTitle className="truncate text-base font-medium" title={title}>
+            {title}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <div
+            className="relative w-full overflow-hidden rounded-md"
+            style={{ minHeight: "480px", maxHeight: "70vh" }}
+          >
+            {isImage ? (
+              <Image
+                src={src}
+                alt={title}
+                fill
+                unoptimized
+                sizes="90vw"
+                style={{ objectFit: "contain" }}
+                onError={() => setBroken(true)}
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+                Preview not available
+              </div>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {mimeType}
+            {sizeLabel ? ` • ${sizeLabel}` : null}
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MediaDialog;


### PR DESCRIPTION
## Summary
- allow dragging image files onto markdown cells to embed them as base64 attachments
- add a visual drop target when files are dragged over a markdown cell
- persist generated markdown so attachments are saved with the cell

## Testing
- pnpm --filter @nodebooks/client lint

------
https://chatgpt.com/codex/tasks/task_e_68dc99283ed0832d9af31a184b3aa0d3