### PR TITLE
feat: add shell cell execution support

### DIFF
--- a/apps/backend/src/notebooks/file.ts
+++ b/apps/backend/src/notebooks/file.ts
@@ -2,16 +2,19 @@ import {
   createCodeCell,
   createEmptyNotebook,
   createMarkdownCell,
+  createShellCell,
   ensureNotebookRuntimeVersion,
   NotebookEnvSchema,
   type CodeCell,
   type MarkdownCell,
+  type ShellCell,
   type Notebook,
   type NotebookCell,
   type NotebookEnv,
   type NotebookFile,
   type NotebookFileCell,
   type NotebookFileCodeCell,
+  type NotebookFileShellCell,
   type NotebookFileNotebook,
 } from "@nodebooks/notebook-schema";
 
@@ -30,6 +33,14 @@ const cloneCells = (cells: NotebookFileCell[]): NotebookCell[] => {
       return createMarkdownCell({
         source: cell.source,
         metadata: cell.metadata ?? {},
+      });
+    }
+    if (cell.type === "shell") {
+      const shellCell = cell as NotebookFileShellCell;
+      return createShellCell({
+        source: shellCell.source,
+        metadata: shellCell.metadata ?? {},
+        outputs: shellCell.outputs ?? [],
       });
     }
     const codeCell = cell as NotebookFileCodeCell;
@@ -105,10 +116,27 @@ const serializeCodeCell = (cell: CodeCell): NotebookFileCell => {
   return result;
 };
 
+const serializeShellCell = (cell: ShellCell): NotebookFileCell => {
+  const result: NotebookFileCell = {
+    type: "shell",
+    source: cell.source,
+  };
+  if (!isEmptyRecord(cell.metadata)) {
+    result.metadata = cell.metadata;
+  }
+  if (cell.outputs && cell.outputs.length > 0) {
+    result.outputs = cell.outputs;
+  }
+  return result;
+};
+
 const serializeCells = (cells: NotebookCell[]): NotebookFileCell[] => {
   return cells.map((cell) => {
     if (cell.type === "markdown") {
       return serializeMarkdownCell(cell);
+    }
+    if (cell.type === "shell") {
+      return serializeShellCell(cell);
     }
     return serializeCodeCell(cell as CodeCell);
   });

--- a/apps/client/components/notebook/add-cell-menu.tsx
+++ b/apps/client/components/notebook/add-cell-menu.tsx
@@ -37,6 +37,15 @@ const AddCellMenu = ({
         <Plus className="h-4 w-4" />
         Code
       </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-2"
+        onClick={() => onAdd("shell")}
+      >
+        <Plus className="h-4 w-4" />
+        Shell
+      </Button>
     </div>
   );
 };

--- a/apps/client/components/notebook/monaco-context-sync.ts
+++ b/apps/client/components/notebook/monaco-context-sync.ts
@@ -10,7 +10,7 @@ import {
 
 type NotebookCell = {
   id: string;
-  type: "code" | "markdown";
+  type: "code" | "markdown" | "shell";
   language?: "js" | "ts";
   source?: string;
 };

--- a/apps/client/components/notebook/shell-cell-view.tsx
+++ b/apps/client/components/notebook/shell-cell-view.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { NotebookCell } from "@nodebooks/notebook-schema";
+import { Badge } from "@/components/ui/badge";
+import OutputView from "@/components/notebook/output-view";
+import { Loader2, Zap } from "lucide-react";
+import { Terminal } from "xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import "xterm/css/xterm.css";
+
+interface ShellCellViewProps {
+  cell: Extract<NotebookCell, { type: "shell" }>;
+  onChange: (
+    updater: (cell: NotebookCell) => NotebookCell,
+    options?: { persist?: boolean; touch?: boolean }
+  ) => void;
+  onRun: () => void;
+  isRunning: boolean;
+  queued?: boolean;
+  editorKey: string;
+}
+
+const ShellCellView = ({
+  cell,
+  onChange,
+  onRun,
+  isRunning,
+  queued,
+  editorKey,
+}: ShellCellViewProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const [terminalReady, setTerminalReady] = useState(false);
+
+  const adjustTextareaHeight = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.max(72, textarea.scrollHeight)}px`;
+  }, []);
+
+  useEffect(() => {
+    adjustTextareaHeight();
+  }, [adjustTextareaHeight, cell.source]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const term = new Terminal({
+      convertEol: true,
+      disableStdin: true,
+      fontFamily:
+        'Menlo, Monaco, "SFMono-Regular", "Fira Code", "Fira Mono", monospace',
+      fontSize: 13,
+      theme: {
+        background: "#020617",
+        foreground: "#e2e8f0",
+      },
+    });
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(container);
+    fitAddon.fit();
+
+    terminalRef.current = term;
+    fitAddonRef.current = fitAddon;
+    setTerminalReady(true);
+
+    const observer = new ResizeObserver(() => {
+      try {
+        fitAddon.fit();
+      } catch (err) {
+        void err;
+      }
+    });
+    observer.observe(container);
+    resizeObserverRef.current = observer;
+
+    return () => {
+      setTerminalReady(false);
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
+      try {
+        term.dispose();
+      } catch (err) {
+        void err;
+      }
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+    };
+  }, [editorKey]);
+
+  const renderTerminal = useCallback(() => {
+    const term = terminalRef.current;
+    if (!term) return;
+    try {
+      term.reset();
+      const command = cell.source.trim();
+      if (command.length > 0) {
+        term.writeln(`$ ${command}`);
+        term.writeln("");
+      }
+      for (const output of cell.outputs) {
+        if (output.type === "stream") {
+          const text = output.text.replace(/\r?\n/g, "\r\n");
+          if (output.name === "stderr") {
+            term.write("\u001b[91m");
+            term.write(text);
+            term.write("\u001b[0m");
+          } else {
+            term.write(text);
+          }
+          continue;
+        }
+        if (output.type === "error") {
+          term.write("\r\n\u001b[91m");
+          term.writeln(`${output.ename}: ${output.evalue}`);
+          for (const line of output.traceback ?? []) {
+            term.writeln(line);
+          }
+          term.write("\u001b[0m");
+          continue;
+        }
+        // Display data is rendered below in OutputView; emit a placeholder line
+        term.write("\r\n");
+      }
+      term.scrollToBottom();
+    } catch (err) {
+      void err;
+    }
+  }, [cell.outputs, cell.source]);
+
+  useEffect(() => {
+    if (!terminalReady) return;
+    renderTerminal();
+  }, [terminalReady, renderTerminal]);
+
+  const supplementalOutputs = useMemo(
+    () =>
+      cell.outputs.filter((output) =>
+        output.type === "display_data" ||
+        output.type === "execute_result" ||
+        output.type === "update_display_data"
+      ),
+    [cell.outputs]
+  );
+
+  const execCount = useMemo(() => {
+    const display = (cell.metadata as { display?: { execCount?: number } })
+      ?.display;
+    return typeof display?.execCount === "number" ? display.execCount : null;
+  }, [cell.metadata]);
+
+  const handleTextareaChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const value = event.target.value;
+      onChange(() => ({ ...cell, source: value }));
+    },
+    [cell, onChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && (event.shiftKey || event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        onRun();
+      }
+    },
+    [onRun]
+  );
+
+  useEffect(() => {
+    adjustTextareaHeight();
+  }, [adjustTextareaHeight, isRunning]);
+
+  return (
+    <div className="rounded-2xl bg-slate-900 text-slate-100 shadow-lg ring-1 ring-slate-900/60">
+      <div className="relative">
+        <div className="absolute left-2 top-2 z-10 flex items-center gap-2 text-[10px] font-semibold">
+          {isRunning ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-400/20 px-2 py-0.5 text-amber-200">
+              <Loader2 className="h-3 w-3 animate-spin" /> Running
+            </span>
+          ) : execCount !== null ? (
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-slate-800/70 px-2 py-0.5 text-slate-200"
+              title={`Last run #${execCount}`}
+            >
+              <Zap className="h-3 w-3 text-emerald-400" /> {execCount}
+            </span>
+          ) : null}
+          {!isRunning && queued ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-indigo-500/20 px-2 py-0.5 text-indigo-200">
+              <span className="h-2 w-2 rounded-full bg-indigo-400" /> Queued
+            </span>
+          ) : null}
+        </div>
+        <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
+          <Badge variant="default" className="px-2 py-0.5 text-[10px] tracking-wide">
+            Shell
+          </Badge>
+        </div>
+        <div className="space-y-3 p-4">
+          <textarea
+            ref={textareaRef}
+            key={editorKey}
+            className="w-full resize-none rounded-xl border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            placeholder="Enter a shell command, e.g. ls -la"
+            value={cell.source}
+            onChange={handleTextareaChange}
+            onKeyDown={handleKeyDown}
+          />
+          <div
+            ref={containerRef}
+            className="h-56 w-full overflow-hidden rounded-xl border border-slate-800 bg-slate-950"
+          />
+          {supplementalOutputs.length > 0 ? (
+            <div className="space-y-2">
+              {supplementalOutputs.map((output, index) => (
+                <OutputView key={index} output={output} />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShellCellView;

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@xterm/addon-fit": "^0.9.0",
     "ansi-to-html": "^0.7.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -34,7 +35,8 @@
     "react-dom": "^19.1.1",
     "swr": "^2.3.6",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "xterm": "^5.3.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/packages/notebook-schema/tests/index.test.ts
+++ b/packages/notebook-schema/tests/index.test.ts
@@ -5,6 +5,7 @@ import {
   createCodeCell,
   createEmptyNotebook,
   createMarkdownCell,
+  createShellCell,
 } from "../src/index.js";
 
 describe("notebook schema", () => {
@@ -17,19 +18,31 @@ describe("notebook schema", () => {
   it("constructs cells with unique identifiers", () => {
     const code = createCodeCell({ source: "console.log('hello');" });
     const markdown = createMarkdownCell({ source: "# Title" });
+    const shell = createShellCell({ source: "ls" });
     expect(code.id).not.toEqual(markdown.id);
+    expect(shell.id).not.toEqual(code.id);
     expect(code.type).toBe("code");
     expect(markdown.type).toBe("markdown");
+    expect(shell.type).toBe("shell");
   });
 
   it("validates kernel protocol messages", () => {
     const request = KernelExecuteRequestSchema.parse({
       type: "execute_request",
+      cellType: "code",
       cellId: "cell-1",
       code: "1 + 2",
       language: "js",
     });
     expect(request.language).toBe("js");
+
+    const shellRequest = KernelExecuteRequestSchema.parse({
+      type: "execute_request",
+      cellType: "shell",
+      cellId: "cell-2",
+      command: "ls",
+    });
+    expect(shellRequest.cellType).toBe("shell");
 
     const message = KernelServerMessageSchema.parse({
       type: "stream",

--- a/packages/runtime-node-worker/src/worker.ts
+++ b/packages/runtime-node-worker/src/worker.ts
@@ -61,9 +61,19 @@ const handleRun = async (payload: IpcRunCell) => {
   };
 
   try {
+    const execOptions =
+      payload.cellType === "shell"
+        ? {
+            cell: payload.cell,
+            command: payload.command,
+          }
+        : {
+            cell: payload.cell,
+            code: payload.code,
+          };
+
     const result = await runtime.execute({
-      cell: payload.cell,
-      code: payload.code,
+      ...execOptions,
       notebookId: payload.notebookId,
       env: payload.env,
       timeoutMs: payload.timeoutMs,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@xterm/addon-fit':
+        specifier: ^0.9.0
+        version: 0.9.0(@xterm/xterm@5.5.0)
       ansi-to-html:
         specifier: ^0.7.2
         version: 0.7.2
@@ -198,6 +201,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.13)
+      xterm:
+        specifier: ^5.3.0
+        version: 5.3.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -2049,6 +2055,14 @@ packages:
 
   '@webgpu/types@0.1.65':
     resolution: {integrity: sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==}
+
+  '@xterm/addon-fit@0.9.0':
+    resolution: {integrity: sha512-hDlPPbTVPYyvwXu/asW8HbJkI/2RMi0cMaJnBZYVeJB0SWP2NeESMCNr+I7CvBlyI0sAxpxOg8Wk4OMkxBz9WA==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
@@ -4795,6 +4809,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  xterm@5.3.0:
+    resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
+    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6335,6 +6353,12 @@ snapshots:
       tinyrainbow: 2.0.0
 
   '@webgpu/types@0.1.65': {}
+
+  '@xterm/addon-fit@0.9.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
 
   abstract-logging@2.0.1: {}
 
@@ -9539,6 +9563,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
+
+  xterm@5.3.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
- extend the shared schema/protocol to cover shell notebook cells and execution requests
- wire the backend, runtime host/worker, and node runtime to spawn shell commands with streaming output
- add an xterm-based `ShellCellView`, expose shell cells in the editor UI, and update helper utilities

## Testing
- pnpm --filter @nodebooks/runtime-node test *(fails: vitest cannot resolve workspace packages without build artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68dddb3fa778832da5dcfdcf413c9049