### PR TITLE
feat: edit on double click

### DIFF
--- a/apps/client/components/notebook/markdown-cell-view.test.tsx
+++ b/apps/client/components/notebook/markdown-cell-view.test.tsx
@@ -127,4 +127,46 @@ describe("MarkdownCellView mermaid rendering", () => {
       expect(block.querySelector("svg")).not.toBeNull();
     }
   });
+
+  it("enters edit mode when the preview is double clicked", async () => {
+    const cell: Extract<NotebookCell, { type: "markdown" }> = {
+      id: "cell-2",
+      type: "markdown",
+      source: "Hello world",
+      metadata: { ui: { edit: false } },
+    };
+
+    const onChange = vi.fn();
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MarkdownCellView
+          cell={cell}
+          notebookId="notebook-1"
+          onChange={onChange as never}
+          editorKey="key"
+        />
+      );
+    });
+
+    const preview =
+      container.querySelector<HTMLDivElement>(".markdown-preview");
+    expect(preview).not.toBeNull();
+
+    await act(async () => {
+      preview?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [updater, options] = onChange.mock.calls[0] as [
+      (current: NotebookCell) => NotebookCell,
+      { persist?: boolean; touch?: boolean } | undefined,
+    ];
+    const updated = updater(cell);
+    expect((updated.metadata as { ui?: { edit?: boolean } }).ui?.edit).toBe(
+      true
+    );
+    expect(options).toBeUndefined();
+  });
 });

--- a/apps/client/components/notebook/markdown-cell-view.tsx
+++ b/apps/client/components/notebook/markdown-cell-view.tsx
@@ -334,6 +334,11 @@ const MarkdownCellView = ({
     [onChange]
   );
 
+  const handlePreviewDoubleClick = useCallback(() => {
+    if (isEditing) return;
+    setEdit(true);
+  }, [isEditing, setEdit]);
+
   const handleMount = useCallback<OnMount>(
     (editor, monaco) => {
       editor.addAction({
@@ -480,6 +485,7 @@ const MarkdownCellView = ({
           <div
             className="markdown-preview space-y-3 text-sm leading-7 text-card-foreground"
             ref={setPreviewRef}
+            onDoubleClick={handlePreviewDoubleClick}
             dangerouslySetInnerHTML={{ __html: html }}
           />
         </div>


### PR DESCRIPTION
This pull request adds support for entering edit mode in the `MarkdownCellView` component when the markdown preview is double-clicked. It updates both the component logic and its associated tests to ensure this interaction works as expected.

**Feature: Edit mode activation via double-click**
* Added a double-click event handler (`onDoubleClick`) to the markdown preview in `MarkdownCellView`, allowing users to enter edit mode by double-clicking the rendered markdown. [[1]](diffhunk://#diff-4d6f2a8d6be0bb7b9210327ddcf2078f05214a1f72dcd821c8f09c3a2c390fd1R337-R341) [[2]](diffhunk://#diff-4d6f2a8d6be0bb7b9210327ddcf2078f05214a1f72dcd821c8f09c3a2c390fd1R488)
* Updated the test suite to verify that double-clicking the preview triggers the correct state change and calls the `onChange` handler to set edit mode.